### PR TITLE
fix comment in insufficientmaterial.js

### DIFF
--- a/protected-owner/scripts/game/insufficientmaterial.js
+++ b/protected-owner/scripts/game/insufficientmaterial.js
@@ -63,7 +63,7 @@ const insufficientmaterial = (function(){
 		const lastMove = movesscript.getLastMove(gamefile.moves);
 		if (lastMove && !lastMove.captured) return false;
 
-		// Temporary: only make the draw check if there are 5 pieces or less
+		// Temporary: only make the draw check if there are less than 5 pieces
         if (gamefileutility.getPieceCountOfGame(gamefile) >= 5) return false;
 
 		// Temporary: only make the draw check if there are no voids


### PR DESCRIPTION
This comment was wrong!
```js
// Temporary: only make the draw check if there are 5 pieces or less
        if (gamefileutility.getPieceCountOfGame(gamefile) >= 5) return false;
```
because this returns false if there are exactly 5 pieces which means it will not make a draw in that case.

this is the comment I wrote instead.
```js
// Temporary: only make the draw check if there are less than 5 pieces
        if (gamefileutility.getPieceCountOfGame(gamefile) >= 5) return false;
```