### PR TITLE
filled in changelog for en-US.toml (previously forgotten)

### DIFF
--- a/translation/changes.json
+++ b/translation/changes.json
@@ -1,3 +1,4 @@
 {
- "1": []
+ "1": ["inital commit of en-US-toml"],
+ "1.0.1": ["added login.login_button on line 448"]
 }


### PR DESCRIPTION
Incredibly minor, but we should stay in the habit of always writing into the changelog what is new to en-US.toml