### PR TITLE
Added legal move highlight outside of a player's turn

### DIFF
--- a/src/client/scripts/game/chess/selection.js
+++ b/src/client/scripts/game/chess/selection.js
@@ -14,6 +14,9 @@ const selection = (function() {
     /** Whether or not the piece selected belongs to the opponent.
      * If so, it's legal moves are rendered a different color, and you aren't allowed to move it.  */
     let isOpponentPiece = false;
+    /** Whether or not the piece selected activated premove mode.
+     * This happens when we select our own pieces, in online games, when it's not our turn. */
+    let isPremove = false;
 
     /** The tile the mouse is hovering over, OR the tile we just performed a simulated click over: `[x,y]` */
     let hoverSquare; // Current square mouse is hovering over
@@ -44,6 +47,12 @@ const selection = (function() {
      * @returns {boolean}
      */
     function isOpponentPieceSelected() { return isOpponentPiece; }
+
+    /**
+     * Returns true if we are in premove mode (i.e. selected our own piece in an online game, when it's not our turn)
+     * @returns {boolean}
+     */
+    function arePremoving() { return isPremove; }
 
     /**
      * Returns the pre-calculated legal moves of the selected piece.
@@ -192,6 +201,7 @@ const selection = (function() {
         const pieceColor = math.getPieceColorFromType(pieceSelected.type);
         isOpponentPiece = onlinegame.areInOnlineGame() ? pieceColor !== onlinegame.getOurColor()
                                /* Local Game */        : pieceColor !== game.getGamefile().whosTurn;
+        isPremove = !isOpponentPiece && onlinegame.areInOnlineGame() && !onlinegame.isItOurTurn();
 
         highlights.regenModel() // Generate the buffer model for the blue legal move fields.
     }
@@ -201,6 +211,8 @@ const selection = (function() {
      */
     function unselectPiece() {
         pieceSelected = undefined;
+        isOpponentPiece = false;
+        isPremove = false;
         legalMoves = undefined;
         pawnIsPromoting = false;
         promoteTo = undefined;
@@ -271,6 +283,7 @@ const selection = (function() {
         promoteToType,
         update,
         renderGhostPiece,
-        isOpponentPieceSelected
+        isOpponentPieceSelected,
+        arePremoving
     })
 })();

--- a/src/client/scripts/game/chess/selection.js
+++ b/src/client/scripts/game/chess/selection.js
@@ -133,12 +133,12 @@ const selection = (function() {
             return;
         }
 
-        // Don't allow players to move a piece of a color not matching the current player's turn
-        const selectedPieceColor = math.getPieceColorFromType(pieceSelected.type);
-        if (selectedPieceColor !== gamefile.whosTurn) return;
-
         // If we haven't return'ed at this point, check if the move is legal.
         if (!hoverSquareLegal) return; // Illegal
+
+        // If it's a premove, hoverSquareLegal should not be true at this point unless
+        // we are actually starting to implement premoving.
+        if (isPremove) throw new Error("Don't know how to premove yet! Will not submit move normally.");
 
         // Don't move the piece if the mesh is locked, because it will mess up the mesh generation algorithm.
         if (gamefile.mesh.locked) return statustext.pleaseWaitForTask(); 

--- a/src/client/scripts/game/chess/selection.js
+++ b/src/client/scripts/game/chess/selection.js
@@ -124,6 +124,10 @@ const selection = (function() {
             return;
         }
 
+        // Don't allow players to move a piece of a color not matching the current player's turn
+        const selectedPieceColor = math.getPieceColorFromType(pieceSelected.type);
+        if (selectedPieceColor !== gamefile.whosTurn) return;
+
         // If we haven't return'ed at this point, check if the move is legal.
         if (!hoverSquareLegal) return; // Illegal
 
@@ -150,9 +154,6 @@ const selection = (function() {
      */
     function handleSelectingPiece(pieceClickedType) {
         const gamefile = game.getGamefile();
-        const clickedPieceColor = math.getPieceColorFromType(pieceClickedType);
-        const clickedFriendlyInOnlineGame = onlinegame.areInOnlineGame() && clickedPieceColor === onlinegame.getOurColor();
-        if (clickedFriendlyInOnlineGame && !onlinegame.isItOurTurn(gamefile)) return; // Not our turn, don't select this piece
 
         // If we're viewing history, return. But also if we clicked a piece, forward moves.
         if (!movesscript.areWeViewingLatestMove(gamefile)) {
@@ -249,8 +250,10 @@ const selection = (function() {
         const typeAtHoverCoords = gamefileutility.getPieceTypeAtCoords(gamefile, hoverSquare);
         const hoverSquareIsSameColor = typeAtHoverCoords && math.getPieceColorFromType(pieceSelected.type) === math.getPieceColorFromType(typeAtHoverCoords);
         const hoverSquareIsVoid = !hoverSquareIsSameColor && typeAtHoverCoords === 'voidsN';
+        // The next boolean ensures that only pieces of the same color as the current player's turn can have a ghost piece:
+        const selectionColorAgreesWithMoveTurn = math.getPieceColorFromType(pieceSelected.type) === gamefile.whosTurn;
         // This will also subtley transfer any en passant capture tags to our `hoverSquare` if the function found an individual move with the tag.
-        hoverSquareLegal = (!isOpponentPiece && legalmoves.checkIfMoveLegal(legalMoves, pieceSelected.coords, hoverSquare)) || (options.getEM() && !hoverSquareIsVoid && !hoverSquareIsSameColor)
+        hoverSquareLegal = (selectionColorAgreesWithMoveTurn && !isOpponentPiece && legalmoves.checkIfMoveLegal(legalMoves, pieceSelected.coords, hoverSquare)) || (options.getEM() && !hoverSquareIsVoid && !hoverSquareIsSameColor)
     }
 
     /** Renders the translucent piece underneath your mouse when hovering over the blue legal move fields. */

--- a/src/client/scripts/game/rendering/options.js
+++ b/src/client/scripts/game/rendering/options.js
@@ -175,7 +175,7 @@ const options = (function() {
 
     function getLegalMoveHighlightColor() {
         if (selection.isOpponentPieceSelected()) return themes[theme].legalMovesHighlightColor_Opponent;
-        else if (onlinegame.areInOnlineGame() && !onlinegame.isItOurTurn()) return themes[theme].legalMovesHighlightColor_Premove;
+        else if (selection.arePremoving()) return themes[theme].legalMovesHighlightColor_Premove;
         else return themes[theme].legalMovesHighlightColor_Friendly;
     }
 

--- a/src/client/scripts/game/rendering/options.js
+++ b/src/client/scripts/game/rendering/options.js
@@ -33,7 +33,7 @@ const options = (function() {
             // legalMovesHighlightColor_Friendly: [1, 0.4, 0,  0.35], // Orange (for sandstone theme)
             // legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.4], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
-            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
+            legalMovesHighlightColor_Premove: [0.3, 0, 1, 0.3],
             lastMoveHighlightColor: [0, 1, 0,  0.25], // 0.17
             // lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
@@ -50,7 +50,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0, 0, 0.5],
             legalMovesHighlightColor_Friendly: [0.6, 0, 1,  0.55],
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
-            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
+            legalMovesHighlightColor_Premove: [0.3, 0, 1, 0.3],
             lastMoveHighlightColor: [0.5, 0.2, 0,  0.75],
             checkHighlightColor: [1, 0, 0.5,  0.76],
             useColoredPieces: true,
@@ -65,7 +65,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
-            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
+            legalMovesHighlightColor_Premove: [0.3, 0, 1, 0.3],
             lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
             useColoredPieces: false,
@@ -80,7 +80,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [0, 0, 1,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
-            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
+            legalMovesHighlightColor_Premove: [0.3, 0, 1, 0.3],
             lastMoveHighlightColor: [0, 0, 0.3,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
             useColoredPieces: true,

--- a/src/client/scripts/game/rendering/options.js
+++ b/src/client/scripts/game/rendering/options.js
@@ -32,7 +32,7 @@ const options = (function() {
             legalMovesHighlightColor_Friendly: [0, 0, 1,  0.35],
             // legalMovesHighlightColor_Friendly: [1, 0.4, 0,  0.35], // Orange (for sandstone theme)
             // legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.4], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
-            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
             legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0, 1, 0,  0.25], // 0.17
             // lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
@@ -49,7 +49,7 @@ const options = (function() {
             darkTiles:  [1, 0.4, 0,  1],
             selectedPieceHighlightColor: [0, 0, 0, 0.5],
             legalMovesHighlightColor_Friendly: [0.6, 0, 1,  0.55],
-            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
             legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0.5, 0.2, 0,  0.75],
             checkHighlightColor: [1, 0, 0.5,  0.76],
@@ -64,7 +64,7 @@ const options = (function() {
             darkTiles: [188/255,160/255,136/255,1],
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
-            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
             legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
@@ -79,7 +79,7 @@ const options = (function() {
             darkTiles: [0/255, 199/255, 238/255, 1],
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [0, 0, 1,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
-            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.3],
             legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0, 0, 0.3,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],

--- a/src/client/scripts/game/rendering/options.js
+++ b/src/client/scripts/game/rendering/options.js
@@ -175,7 +175,7 @@ const options = (function() {
 
     function getLegalMoveHighlightColor() {
         if (selection.isOpponentPieceSelected()) return themes[theme].legalMovesHighlightColor_Opponent;
-        else if (onlinegame.areInOnlineGame() && !onlinegame.isItOurTurn(game.getGamefile())) return themes[theme].legalMovesHighlightColor_Premove;
+        else if (onlinegame.areInOnlineGame() && !onlinegame.isItOurTurn()) return themes[theme].legalMovesHighlightColor_Premove;
         else return themes[theme].legalMovesHighlightColor_Friendly;
     }
 

--- a/src/client/scripts/game/rendering/options.js
+++ b/src/client/scripts/game/rendering/options.js
@@ -33,6 +33,7 @@ const options = (function() {
             // legalMovesHighlightColor_Friendly: [1, 0.4, 0,  0.35], // Orange (for sandstone theme)
             // legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.4], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0, 1, 0,  0.25], // 0.17
             // lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
@@ -49,6 +50,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0, 0, 0.5],
             legalMovesHighlightColor_Friendly: [0.6, 0, 1,  0.55],
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0.5, 0.2, 0,  0.75],
             checkHighlightColor: [1, 0, 0.5,  0.76],
             useColoredPieces: true,
@@ -63,6 +65,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [1, 0.2, 0,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0.3, 1, 0,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
             useColoredPieces: false,
@@ -77,6 +80,7 @@ const options = (function() {
             selectedPieceHighlightColor: [0, 0.5, 0.5,  0.3],
             legalMovesHighlightColor_Friendly: [0, 0, 1,  0.35], // Red-orange (for wood theme)   0.5 for BIG positions   0.35 for SMALL
             legalMovesHighlightColor_Opponent: [0.7, 0, 0, 0.35],
+            legalMovesHighlightColor_Premove: [1, 0.7, 0, 0.35],
             lastMoveHighlightColor: [0, 0, 0.3,  0.35], // For sandstone theme   0.3 for small, 0.35 for BIG positions
             checkHighlightColor: [1, 0, 0,  0.7],
             useColoredPieces: true,
@@ -170,7 +174,9 @@ const options = (function() {
     }
 
     function getLegalMoveHighlightColor() {
-        return selection.isOpponentPieceSelected() ? themes[theme].legalMovesHighlightColor_Opponent : themes[theme].legalMovesHighlightColor_Friendly;
+        if (selection.isOpponentPieceSelected()) return themes[theme].legalMovesHighlightColor_Opponent;
+        else if (onlinegame.areInOnlineGame() && !onlinegame.isItOurTurn(game.getGamefile())) return themes[theme].legalMovesHighlightColor_Premove;
+        else return themes[theme].legalMovesHighlightColor_Friendly;
     }
 
     function getDefaultSelectedPieceHighlight() {


### PR DESCRIPTION
In online games, when it's not a player's turn, clicking their own pieces shows what their legal moves would be.