### PR TITLE
add functionality to pass in engine to be used as parameter to enginegame

### DIFF
--- a/src/client/scripts/game/chess/engineRandomRoyalMoves.js
+++ b/src/client/scripts/game/chess/engineRandomRoyalMoves.js
@@ -6,7 +6,7 @@
 
 "use strict";
 
-const engine = (function(){
+const engineRandomRoyalMoves = (function(){
 
     /**
      * Main function of this script. It gets called as soon as the human player submits a move.
@@ -35,9 +35,9 @@ const engine = (function(){
      */
     function getRandomRoyalMove(gamefile, color) {
         const royalCoords = gamefileutility.getRoyalCoords(gamefile, color)[0]
-        const blackRoyalPiece = gamefileutility.getPieceAtCoords(gamefile, royalCoords);
-        const blackmoves = legalmoves.calculate(gamefile, blackRoyalPiece).individual;
-        const randomEndCoords = blackmoves[Math.floor(Math.random() * blackmoves.length)]; // random endcoords from the list of individual moves
+        const royalPiece = gamefileutility.getPieceAtCoords(gamefile, royalCoords);
+        const moves = legalmoves.calculate(gamefile, royalPiece).individual;
+        const randomEndCoords = moves[Math.floor(Math.random() * moves.length)]; // random endcoords from the list of individual moves
         const move = {startCoords: royalCoords, endCoords: randomEndCoords};
         specialdetect.transferSpecialFlags_FromCoordsToMove(randomEndCoords, move);
         return move;

--- a/src/client/scripts/game/chess/engineRandomRoyalMoves.js
+++ b/src/client/scripts/game/chess/engineRandomRoyalMoves.js
@@ -1,7 +1,7 @@
 /**
- * This script runs the chess engine for enginegames.
- * It is modular and may be replaced by any other engine script to test a different engine.
- * To that end, engine.runEngine(gamefile) is the only function that is called from the outside.
+ * This script runs a very basic chess engine for enginegames that just computes a random move for the black royal piece.
+ * runEngine(gamefile) is the only function that is called from the outside.
+ * You may specify a different engine to be used by specifying a different engine name in the gameOptions when initializing an engine game.
  */
 
 "use strict";
@@ -12,7 +12,7 @@ const engineRandomRoyalMoves = (function(){
      * Main function of this script. It gets called as soon as the human player submits a move.
      * It takes a gamefile as an input and computes a move.
      * @param {gamefile} gamefile - gamefile of the current game
-     * @returns {Promise} - promise which resolves to some engine move
+     * @returns {Promise<Move>} - promise which resolves to some engine move
      */
     async function runEngine(gamefile) {
         try {

--- a/src/client/scripts/game/gui/guipractice.js
+++ b/src/client/scripts/game/gui/guipractice.js
@@ -138,6 +138,7 @@ const guipractice = (function(){
             },
             youAreColor: 'white',
             clock: "-",
+            currentEngine: 'engineRandomRoyalMoves',
             variantOptions: {
                 turn: "white",
                 fullMove: "1",
@@ -152,7 +153,7 @@ const guipractice = (function(){
         }
         enginegame.setColorAndGameID(gameOptions)
         loadGame(gameOptions)
-        enginegame.initEngineGame()
+        enginegame.initEngineGame(gameOptions)
         clock.set(gameOptions.clock)
         guigameinfo.revealPlayerNames(gameOptions)
     }

--- a/src/client/scripts/game/gui/guipractice.js
+++ b/src/client/scripts/game/gui/guipractice.js
@@ -138,7 +138,7 @@ const guipractice = (function(){
             },
             youAreColor: 'white',
             clock: "-",
-            currentEngine: 'engineRandomRoyalMoves',
+            currentEngine: engineRandomRoyalMoves,
             variantOptions: {
                 turn: "white",
                 fullMove: "1",

--- a/src/client/scripts/game/misc/enginegame.js
+++ b/src/client/scripts/game/misc/enginegame.js
@@ -8,12 +8,15 @@ const enginegame = (function(){
     /** Whether we are currently in an engine game. */
     let inEngineGame = false
     let ourColor; // white/black
+    let currentEngine; // name of the current engine used
 
     const engineTimeLimitPerMoveMillis = 1000;
 
     function areInEngineGame() { return inEngineGame }
 
     function getOurColor() { return ourColor }
+
+    function getCurrentEngine() { return currentEngine }
 
     /**
      * This has to be called before and separate from {@link initEngineGame}
@@ -23,20 +26,27 @@ const enginegame = (function(){
     function setColorAndGameID(gameOptions) {
         inEngineGame = true
         ourColor = gameOptions.youAreColor;
+        
     }
 
     /**
      * Inits an engine game
+     * @param {Object} gameOptions - An object that contains the property `currentEngine`
      */
-    function initEngineGame () {
+    function initEngineGame (gameOptions) {
         // This make sure it will place us in black's perspective if applicable
         perspective.resetRotations()
+
+        currentEngine = gameOptions.currentEngine;
+        if (currentEngine) console.log(`Started engine game with engine ${currentEngine}`);
+        else console.error ("Attempting to start game with unknown engine!");
     }
 
     // Call when we leave an engine game
     function closeEngineGame() {
         inEngineGame = false;
         ourColor = undefined;
+        currentEngine = undefined;
         perspective.resetRotations() // Without this, leaving an engine game of which we were black, won't reset our rotation.
     }
 
@@ -70,9 +80,10 @@ const enginegame = (function(){
      */
     async function makeEngineMove() {
         if (!inEngineGame) return;
+        if (!currentEngine) console.error ("Attempting to make move with unknown engine!");
         
         const gamefile = game.getGamefile();
-        const move = await engine.runEngine(gamefile);
+        const move = await eval(currentEngine).runEngine(gamefile);
 
         const piecemoved = gamefileutility.getPieceAtCoords(gamefile, move.startCoords)
         const legalMoves = legalmoves.calculate(gamefile, piecemoved);
@@ -91,6 +102,7 @@ const enginegame = (function(){
     return Object.freeze({
         areInEngineGame,
         getOurColor,
+        getCurrentEngine,
         setColorAndGameID,
         initEngineGame,
         closeEngineGame,

--- a/src/client/scripts/game/misc/enginegame.js
+++ b/src/client/scripts/game/misc/enginegame.js
@@ -37,9 +37,13 @@ const enginegame = (function(){
         // This make sure it will place us in black's perspective if applicable
         perspective.resetRotations()
 
-        currentEngine = gameOptions.currentEngine;
-        if (currentEngine) console.log(`Started engine game with engine ${currentEngine}`);
-        else console.error ("Attempting to start game with unknown engine!");
+        try{
+            if (!gameOptions.currentEngine || !eval(gameOptions.currentEngine)) throw new Error();
+            currentEngine = gameOptions.currentEngine;
+            console.log(`Started engine game with engine ${currentEngine}`);
+        } catch(e) {
+            console.error (`Attempting to start game with unknown engine: ${gameOptions.currentEngine}`);
+        }
     }
 
     // Call when we leave an engine game
@@ -80,7 +84,7 @@ const enginegame = (function(){
      */
     async function makeEngineMove() {
         if (!inEngineGame) return;
-        if (!currentEngine) console.error ("Attempting to make move with unknown engine!");
+        if (!currentEngine) return console.error ("Attempting to make engine move, but no engine loaded!");
         
         const gamefile = game.getGamefile();
         const move = await eval(currentEngine).runEngine(gamefile);

--- a/src/client/scripts/game/misc/enginegame.js
+++ b/src/client/scripts/game/misc/enginegame.js
@@ -30,7 +30,7 @@ const enginegame = (function(){
     }
 
     /**
-     * Inits an engine game
+     * Inits an engine game. In particular, it needs gameOptions in order to know what engine to use for this enginegame.
      * @param {Object} gameOptions - An object that contains the property `currentEngine`
      */
     function initEngineGame (gameOptions) {

--- a/src/client/scripts/game/misc/enginegame.js
+++ b/src/client/scripts/game/misc/enginegame.js
@@ -37,13 +37,9 @@ const enginegame = (function(){
         // This make sure it will place us in black's perspective if applicable
         perspective.resetRotations()
 
-        try{
-            if (!gameOptions.currentEngine || !eval(gameOptions.currentEngine)) throw new Error();
-            currentEngine = gameOptions.currentEngine;
-            console.log(`Started engine game with engine ${currentEngine}`);
-        } catch(e) {
-            console.error (`Attempting to start game with unknown engine: ${gameOptions.currentEngine}`);
-        }
+        currentEngine = gameOptions.currentEngine
+        if (!currentEngine) return console.error (`Attempting to start game with unknown engine: ${currentEngine}`);
+        console.log(`Started engine game with engine ${currentEngine}`);
     }
 
     // Call when we leave an engine game
@@ -87,7 +83,7 @@ const enginegame = (function(){
         if (!currentEngine) return console.error ("Attempting to make engine move, but no engine loaded!");
         
         const gamefile = game.getGamefile();
-        const move = await eval(currentEngine).runEngine(gamefile);
+        const move = await currentEngine.runEngine(gamefile);
 
         const piecemoved = gamefileutility.getPieceAtCoords(gamefile, move.startCoords)
         const legalMoves = legalmoves.calculate(gamefile, piecemoved);


### PR DESCRIPTION
Now that people are writing different engines, it would be nice if every engine could be its own separate file. And when starting an engine game, the engine to be used will just be a parameter in gameOptions.