### PR TITLE
Keep variant name on translation failure

### DIFF
--- a/src/client/scripts/game/chess/copypastegame.js
+++ b/src/client/scripts/game/chess/copypastegame.js
@@ -57,7 +57,7 @@ const copypastegame = (function(){
         const gameRulesCopy = math.deepCopyObject(gamefile.gameRules);
 
         primedGamefile.metadata = gamefile.metadata;
-        primedGamefile.metadata.Variant = translations[primedGamefile.metadata.Variant]; // Convert the variant metadata code to spoken language
+        primedGamefile.metadata.Variant = translations[primedGamefile.metadata.Variant] || primedGamefile.metadata.Variant; // Convert the variant metadata code to spoken language
         primedGamefile.turn = gamefile.startSnapshot.turn;
         primedGamefile.enpassant = gamefile.startSnapshot.enpassant;
         if (gameRulesCopy.moveRule) primedGamefile.moveRule = `${gamefile.startSnapshot.moveRuleState}/${gameRulesCopy.moveRule}`; delete gameRulesCopy.moveRule;
@@ -214,7 +214,7 @@ const copypastegame = (function(){
         }
 
         // The variant metadata needs to be converted from language-specific to internal game code
-        longformat.metadata.Variant = convertVariantFromSpokenLanguageToCode(longformat.metadata.Variant)
+        longformat.metadata.Variant = convertVariantFromSpokenLanguageToCode(longformat.metadata.Variant) || longformat.metadata.Variant
 
         delete longformat.metadata.Clock;
 

--- a/src/client/scripts/game/chess/copypastegame.js
+++ b/src/client/scripts/game/chess/copypastegame.js
@@ -57,7 +57,7 @@ const copypastegame = (function(){
         const gameRulesCopy = math.deepCopyObject(gamefile.gameRules);
 
         primedGamefile.metadata = gamefile.metadata;
-        primedGamefile.metadata.Variant = translations[primedGamefile.metadata.Variant] || primedGamefile.metadata.Variant; // Convert the variant metadata code to spoken language
+        primedGamefile.metadata.Variant = translations[primedGamefile.metadata.Variant] || primedGamefile.metadata.Variant; // Convert the variant metadata code to spoken language if translation is available
         primedGamefile.turn = gamefile.startSnapshot.turn;
         primedGamefile.enpassant = gamefile.startSnapshot.enpassant;
         if (gameRulesCopy.moveRule) primedGamefile.moveRule = `${gamefile.startSnapshot.moveRuleState}/${gameRulesCopy.moveRule}`; delete gameRulesCopy.moveRule;
@@ -213,7 +213,7 @@ const copypastegame = (function(){
             longformat.metadata.UTCTime = UTCTime;
         }
 
-        // The variant metadata needs to be converted from language-specific to internal game code
+        // If the variant has been translated, the variant metadata needs to be converted from language-specific to internal game code else keep it the same
         longformat.metadata.Variant = convertVariantFromSpokenLanguageToCode(longformat.metadata.Variant) || longformat.metadata.Variant
 
         delete longformat.metadata.Clock;


### PR DESCRIPTION
Small fix so custom variants can keep variant name when copy/pasted