### PR TITLE
Fix broken header on firefox

### DIFF
--- a/src/client/css/header.css
+++ b/src/client/css/header.css
@@ -141,7 +141,7 @@ nav {
 nav a {
     padding: 0 calc(var(--header-link-max-padding)) 0;
 	white-space: nowrap; /* Prevent text from wrapping */
-	overflow: hidden; /* Hide overflow if needed */
+	overflow: clip; /* Hide overflow if needed */
 }
 
 nav span {


### PR DESCRIPTION
Before, on firefox:
![grafik](https://github.com/user-attachments/assets/c5b22cad-545b-4f94-9f10-4abbe450c2a2)

After, on firefox:
![grafik](https://github.com/user-attachments/assets/fb422bfd-13c7-415d-bb3b-9aba8ac309b6)
