### PR TITLE
Fixed bug with importing games with an invalid enpassant square causing a crash when you click a pawn (NOT …

### DIFF
--- a/src/client/scripts/esm/game/chess/copypastegame.js
+++ b/src/client/scripts/esm/game/chess/copypastegame.js
@@ -18,6 +18,8 @@ import winconutil from '../../chess/util/winconutil.js';
 import guinavigation from '../gui/guinavigation.js';
 import gameslot from './gameslot.js';
 import gameloader from './gameloader.js';
+import colorutil from '../../chess/util/colorutil.js';
+import coordutil from '../../chess/util/coordutil.js';
 // Import End
 
 "use strict";
@@ -266,9 +268,18 @@ async function pasteGame(longformat) { // game: { startingPosition (key-list), p
 		// longformat.enpassant is in the form: Coords
 		// need to convert it to: { square: Coords, pawn: Coords }
 		const firstTurn = longformat.gameRules.turnOrder[0];
-		const oneOrNegOne = firstTurn === 'white' ? 1 : firstTurn === 'black' ? -1 : (() => { throw new Error("Invalid turn order when pasting a game! Can't parse enpassant option."); })();
-		const newEnPassant = { square: longformat.enpassant, pawn: [longformat.enpassant[0], longformat.enpassant[1] - oneOrNegOne] };
-		variantOptions.enpassant = newEnPassant;
+		const yParity = firstTurn === 'white' ? 1 : firstTurn === 'black' ? -1 : (() => { throw new Error(`Invalid first turn "${firstTurn}" when pasting a game! Can't parse enpassant option.`); })();
+		const pawnExpectedSquare = [longformat.enpassant[0], longformat.enpassant[1] - yParity];
+		/**
+		 * First make sure there IS a pawn on the square!
+		 * If not, the ICN was likely tampered.
+		 * Erase the enpassant property! (or just don't transfer it over)
+		 */
+		const pieceOnExpectedSquare = longformat.startingPosition[coordutil.getKeyFromCoords(pawnExpectedSquare)];
+		if (pieceOnExpectedSquare && pieceOnExpectedSquare.startsWith('pawns') && colorutil.getPieceColorFromType(pieceOnExpectedSquare) !== firstTurn) {
+			// Valid pawn to capture via enpassant is present
+			variantOptions.enpassant = { square: longformat.enpassant, pawn: pawnExpectedSquare };
+		}
 	}
 
 	if (onlinegame.areInOnlineGame() && onlinegame.getIsPrivate()) {


### PR DESCRIPTION
…TESTED), by not transferring the property if there isn't a valid pawn to capture via enpassant