### PR TITLE
Patch incorrect display message when accepting an invite a fraction of a second after no longer available.

### DIFF
--- a/src/client/scripts/esm/game/misc/invites.js
+++ b/src/client/scripts/esm/game/misc/invites.js
@@ -375,7 +375,7 @@ function click(element) {
 		if (!guiplay.isCreateInviteButtonLocked()) cancel(invite.id);
 	} else {
 		// Not our invite, accept the one we clicked
-		if (!guiplay.isAcceptInviteButtonLocked()) accept(invite.id, true);
+		if (!guiplay.isAcceptInviteButtonLocked()) accept(invite.id, false);
 	}
 }
 


### PR DESCRIPTION
The correct message should be "Game aborted."