### PR TITLE
Updated the year and replaced (c) by © in COPYING.md

### DIFF
--- a/docs/COPYING.md
+++ b/docs/COPYING.md
@@ -1,6 +1,6 @@
 # Copying Infinite Chess
 
-Any file in this project that does not state otherwise and is not listed as an exception below is part of Infinite Chess and copyright (c) 2023-2024 Naviary (InfiniteChess.org).
+Any file in this project that does not state otherwise and is not listed as an exception below is part of Infinite Chess and copyright © 2023-2026 Naviary (InfiniteChess.org).
 
 Infinite Chess is free software; you can redistribute and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version. Any works derived from this software must also be released under the same license.
 


### PR DESCRIPTION
In `COPYING.md`, I:
- Updated the year of the copyright from 2023-2024 to 2023-2026.
- Replaced (c) by a true copyright character, ©.