### PR TITLE
Corrected a typo in the ToS

### DIFF
--- a/translation/en-US.toml
+++ b/translation/en-US.toml
@@ -561,7 +561,7 @@ fair_play_paragraph1 = ["You cannot have more than one account."]
 fair_play_paragraph2 = "To keep play fun and fair for everyone, you must NOT:"
 fair_play_rules = [
 "Modify or manipulate the code in any way, including but not limited to: Using console commands, local overrides, custom scripts, modifying http requests, websocket messages, etc. This can be done to intentionally break the game, play otherwise illegal moves, or to give you an advantage.",
-"Abuse bugs or glitches in order to abort the game, or give you an advantantage.",
+"Abuse bugs or glitches in order to abort the game, or give you an advantage.",
 "In rated games, receive help/advice from another person or program as to what you should play. (Creating an engine is ok and encouraged, but you must limit its use to unrated, casual, games)",
 "Trade elo points with other people by purposefully losing with intent to boost the elo of your opponent, or by receiving elo points from an opponent that intends to lose to boost your own rating. This abuses the system and creates unaccurate ratings according to your level of skill."
 ]


### PR DESCRIPTION
### Type of Change:

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor (no logic change)
- [X] Changing strings (include translation)

### Scope (what part of the website or game does it apply to):

The [Terms of Service](https://www.infinitechess.org/termsofservice).

### Details of what it does (if it makes UI changes, include screenshots of the before & after):

I just corrected a typo removing 3 characters: “advantantage” → “advantage”. 

<img width="668" height="19" alt="Abuse bugs or glitches in order to abort the game, or give you an advantantage." src="https://github.com/user-attachments/assets/ad5d84c2-1a6d-44d8-a411-dd1488816e1c"/>
<img width="642" height="21" alt="Abuse bugs or glitches in order to abort the game, or give you an advantage." src="https://github.com/user-attachments/assets/0bc63a6f-94f7-4584-b83a-d1da7a3f9cec"/>

There is the same typo in a news article, but I have been told not to change news articles written in English even if there is a mistake.

<img width="714" height="146" alt="Players may not abuse bugs or glitches in order to abort the game, play otherwise illegal moves, give you an advantantage, or make the game otherwise unplayable." src="https://github.com/user-attachments/assets/2511c58f-b9ce-49c5-9c45-3390175a72f9"/>