### PR TITLE
Add "cloud" button to saved positions UI

### DIFF
--- a/src/client/css/play.css
+++ b/src/client/css/play.css
@@ -1658,7 +1658,7 @@ svg.collapse {
 
 .saved-position-columns {
 	display: grid;
-	grid-template-columns: 43% 22% 35%;
+	grid-template-columns: 35% 22% 35%;
 	align-items: center;
 	padding: 0 0.35em;
 }
@@ -1681,7 +1681,7 @@ svg.collapse {
 	border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 	display: grid;
 	align-items: center;
-	grid-template-columns: auto 13% 25% 8% 8%;
+	grid-template-columns: auto 13% 25% 8% 8% 8%;
 	padding: 0 0.35em;
 }
 

--- a/src/client/scripts/esm/game/gui/boardeditor/guiloadposition.ts
+++ b/src/client/scripts/esm/game/gui/boardeditor/guiloadposition.ts
@@ -282,6 +282,9 @@ function createButtonElement(svgHref: string): HTMLButtonElement {
  *   <button class="btn saved-position-btn">
  *     <svg><use href="#svg-load" /></svg>
  *   </button>
+ * 	 <button class="btn saved-position-btn">
+ *     <svg><use href="#svg-cloud" /></svg>
+ *   </button>
  *   <!-- Delete -->
  *   <button class="btn saved-position-btn">
  *     <svg><use href="#svg-delete" /></svg>
@@ -331,6 +334,12 @@ function generateRowForSavedPositionsElement(
 	const loadBtn = createButtonElement('#svg-load');
 	registerButtonClick(loadBtn, () => openModal('load', positionname, saveinfo_key, save_key));
 	row.appendChild(loadBtn);
+
+	// "Cloud" button
+	const cloudBtn = createButtonElement('#svg-cloud');
+	// TODO: Write listener function which moves position to and from server
+	// registerButtonClick(cloudBtn, () => {});
+	row.appendChild(cloudBtn);
 
 	// "Delete" button
 	const deleteBtn = createButtonElement('#svg-delete');

--- a/src/client/views/play.ejs
+++ b/src/client/views/play.ejs
@@ -46,6 +46,17 @@
                     <path d="M5.495 2.573 1.5.143C.832-.266 0 .25 0 1.068V5.93c0 .82.832 1.333 1.5.927l3.995-2.43c.673-.41.673-1.445 0-1.855" fill-rule="evenodd"/>
                 </symbol>
             </svg>
+            <!-- Cloud -->
+            <svg>
+                <metadata>
+                    Author: Iconsax
+                    License: MIT License
+                    Source: https://www.svgrepo.com/svg/495161/cloud/
+                </metadata>
+                <symbol id="svg-cloud" fill="#333" viewBox="0 0 24 24">
+                    <path d="M21.74 12.9089c-.26-.86-.69-1.61-1.26-2.22-.73-.83-1.7-1.4-2.79-1.65-.55-2.5-2.09-4.3-4.28-4.97-2.38-.74-5.14-.02-6.87 1.79-1.52 1.59-2.02 3.78-1.43 6.11-2 .49-2.99 2.16-3.1 3.75-.01.11-.01.21-.01.31 0 1.88 1.23 3.99 3.97 4.19h10.38c1.42 0 2.78-.53 3.82-1.48 1.63-1.43 2.23-3.66 1.57-5.83Z"/>
+                </symbol>
+            </svg>
         </div>
 
         <main>
@@ -653,6 +664,9 @@
                                 <div>
                                     <button class="btn saved-position-btn">
                                         <svg><use href="#svg-load" /></svg>
+                                    </button>
+                                    <button class="btn saved-position-btn">
+                                        <svg><use href="#svg-cloud" /></svg>
                                     </button>
                                     <button class="btn saved-position-btn">
                                         <svg><use href="#svg-delete" /></svg>


### PR DESCRIPTION
### Type of Change:
UI change

### Scope:
Board Editor Saved Positions UI

### Details of what it does:
Add dummy "cloud" button to saved positions UI. No logic changes yet.

<img width="411" height="136" alt="image" src="https://github.com/user-attachments/assets/301eb242-dda3-4d0a-8f58-b27df40d0be1" />
