### PR TITLE
Put tooltips in palette board at the top instead of bottom

### DIFF
--- a/src/client/css/header.css
+++ b/src/client/css/header.css
@@ -758,7 +758,7 @@ p.theme-title {
 	border-color: transparent transparent black transparent;
 }
 
-/* Arrow pointing upward (used for tooltip-u / tooltip-ul) */
+/* Arrow pointing upward (used for tooltip-u / tooltip-ul / tooltip-ur) */
 #tooltip-arrow.tooltip-arrow-up {
 	border-color: black transparent transparent transparent;
 }

--- a/src/client/scripts/esm/game/gui/boardeditor/guipalette.ts
+++ b/src/client/scripts/esm/game/gui/boardeditor/guipalette.ts
@@ -94,8 +94,8 @@ async function initUI(): Promise<void> {
 			svg.classList.add('piece');
 			const pieceContainer = document.createElement('div');
 
-			if (i % 4 === 0) pieceContainer.classList.add('tooltip-dr');
-			else pieceContainer.classList.add('tooltip-d');
+			if (i % 4 === 0) pieceContainer.classList.add('tooltip-ur');
+			else pieceContainer.classList.add('tooltip-u');
 			const localized_piece_name =
 				// @ts-ignore
 				translations.piecenames[typeutil.getRawTypeStr(coloredTypes[i]!)!];
@@ -130,7 +130,7 @@ async function initUI(): Promise<void> {
 	element_void.id = '0';
 
 	// Void tooltip
-	element_void.classList.add('tooltip-dr');
+	element_void.classList.add('tooltip-ur');
 	// @ts-ignore
 	const localized_void_name = translations.piecenames[typeutil.getRawTypeStr(r.VOID)!];
 	const void_abbreviation = icnconverter.piece_codes_raw[r.VOID];
@@ -145,9 +145,9 @@ async function initUI(): Promise<void> {
 		const pieceContainer = document.createElement('div');
 
 		// Neutral piece tooltips
-		if (i % 4 === 3) pieceContainer.classList.add('tooltip-dr');
-		else if (i % 4 === 2) pieceContainer.classList.add('tooltip-dl');
-		else pieceContainer.classList.add('tooltip-d');
+		if (i % 4 === 3) pieceContainer.classList.add('tooltip-ur');
+		else if (i % 4 === 2) pieceContainer.classList.add('tooltip-ul');
+		else pieceContainer.classList.add('tooltip-u');
 		const localized_piece_name =
 			// @ts-ignore
 			translations.piecenames[typeutil.getRawTypeStr(neutralTypes[i]!)!];

--- a/src/client/scripts/esm/util/tooltips.ts
+++ b/src/client/scripts/esm/util/tooltips.ts
@@ -1,7 +1,5 @@
 // src/client/scripts/esm/util/tooltips.ts
 
-// src/client/scripts/esm/util/tooltips.ts
-
 /**
  * JS-based tooltip system using event delegation. A single fixed div is appended to document.body
  * when the user hovers a tooltip element, avoiding any clipping issues from parent containers.

--- a/src/client/scripts/esm/util/tooltips.ts
+++ b/src/client/scripts/esm/util/tooltips.ts
@@ -1,5 +1,7 @@
 // src/client/scripts/esm/util/tooltips.ts
 
+// src/client/scripts/esm/util/tooltips.ts
+
 /**
  * JS-based tooltip system using event delegation. A single fixed div is appended to document.body
  * when the user hovers a tooltip element, avoiding any clipping issues from parent containers.
@@ -13,6 +15,7 @@
  *   tooltip-dr  – below, left-aligned to element
  *   tooltip-u   – above, centered
  *   tooltip-ul  – above, right-aligned to element
+ *   tooltip-ur  – above, left-aligned to element
  *
  * Tooltip text comes from the element's data-tooltip attribute.
  */
@@ -27,6 +30,7 @@ const tooltipClasses: string[] = [
 	'tooltip-dr',
 	'tooltip-u',
 	'tooltip-ul',
+	'tooltip-ur',
 ];
 /** CSS selector matching any element that is a tooltip target (has both a direction class and data-tooltip). */
 const TOOLTIP_SELECTOR = tooltipClasses.map((cls) => `.${cls}[data-tooltip]`).join(', ');


### PR DESCRIPTION
### Type of Change (new feature, quality of life, bug fix, refactor, tooling, chore, tests, translation, or documentation):
Bug fix
### Scope (what part of the website or game does it apply to):
Board editor
### Details of what it does (if it makes css style changes, include screenshots of the before & after):
This pull request repositions the tooltips in the palette from the bottom to the top as shown in the image below.

**Before**
<img width="500" height="369" alt="image" src="https://github.com/user-attachments/assets/0d7071ec-3a72-47c4-a446-4b08701f7541" />

**After (the tooltip is now visible)**
<img width="500" height="375" alt="image" src="https://github.com/user-attachments/assets/61b39279-af49-4e49-88a8-fc94215af080" />

