### PR TITLE
Add Green Highlight Move Hints

### DIFF
--- a/src/client/scripts/esm/game/chess/gameloader.ts
+++ b/src/client/scripts/esm/game/chess/gameloader.ts
@@ -84,17 +84,15 @@ function areInLocalGame(): boolean {
 	return typeOfGameWeAreIn === 'local';
 }
 
-function isItOurTurn(color?: Player): boolean {
+function isItOurTurn(): boolean {
 	if (typeOfGameWeAreIn === undefined)
 		throw Error("Can't tell if it's our turn when we're not in a game!");
 	if (typeOfGameWeAreIn === 'online') return onlinegame.isItOurTurn();
 	else if (typeOfGameWeAreIn === 'engine') return enginegame.isItOurTurn();
 	else if (typeOfGameWeAreIn === 'editor') return true;
-	else if (typeOfGameWeAreIn === 'local') {
-		if (color === undefined) return true; // Always our turn in this case
-		// A specific color was specified as "us", check against that.
-		return gameslot.getGamefile()!.basegame.whosTurn === color;
-	} else
+	else if (typeOfGameWeAreIn === 'local')
+		return true; // Always our turn in this case
+	else
 		throw Error(
 			"Don't know how to tell if it's our turn in this type of game: " + typeOfGameWeAreIn,
 		);

--- a/src/client/scripts/esm/game/chess/gameloader.ts
+++ b/src/client/scripts/esm/game/chess/gameloader.ts
@@ -90,9 +90,11 @@ function isItOurTurn(color?: Player): boolean {
 	if (typeOfGameWeAreIn === 'online') return onlinegame.isItOurTurn();
 	else if (typeOfGameWeAreIn === 'engine') return enginegame.isItOurTurn();
 	else if (typeOfGameWeAreIn === 'editor') return true;
-	else if (typeOfGameWeAreIn === 'local')
+	else if (typeOfGameWeAreIn === 'local') {
+		if (color === undefined) return true; // Always our turn in this case
+		// A specific color was specified as "us", check against that.
 		return gameslot.getGamefile()!.basegame.whosTurn === color;
-	else
+	} else
 		throw Error(
 			"Don't know how to tell if it's our turn in this type of game: " + typeOfGameWeAreIn,
 		);

--- a/src/client/scripts/esm/game/chess/selection.ts
+++ b/src/client/scripts/esm/game/chess/selection.ts
@@ -372,7 +372,7 @@ function canSelectPieceType(basegame: Game, type: number | undefined): 0 | 1 | 2
 	if (player === p.NEUTRAL) return 0; // Can't select neutrals, period.
 	if (isOpponentType(basegame, type)) return 1; // Can select opponent pieces, but not draggable..
 	// It is our piece type...
-	const isOurTurn = gameloader.isItOurTurn(player);
+	const isOurTurn = gameloader.isItOurTurn();
 	if (!isOurTurn && !preferences.getPremoveEnabled()) return 1; // Can select our piece when it's not our turn, but not draggable.
 	return preferences.getDragEnabled() ? 2 : 1; // Can select and move this piece type (draggable too IF THAT IS ENABLED).
 }

--- a/src/client/scripts/esm/game/chess/selection.ts
+++ b/src/client/scripts/esm/game/chess/selection.ts
@@ -385,7 +385,7 @@ function canMovePieceType(pieceType: number): boolean {
 	const isOpponentPiece = isOpponentType(gameslot.getGamefile()!.basegame, pieceType);
 	if (isOpponentPiece) return false; // Don't move opponent pieces
 	// It is our piece type...
-	const isOurTurn = gameloader.areInLocalGame() || gameloader.isItOurTurn();
+	const isOurTurn = gameloader.isItOurTurn();
 	if (isOurTurn) return true; // Can always move pieces on our turn
 	return preferences.getPremoveEnabled(); // If it's not out turn, can only move if premoving is enabled.
 }
@@ -509,7 +509,7 @@ function initSelectedPieceInfo(gamefile: FullGame, mesh: Mesh | undefined, piece
 	pieceSelected = piece;
 
 	isOpponentPiece = isOpponentType(gamefile.basegame, piece.type);
-	isPremove = !isOpponentPiece && !gameloader.areInLocalGame() && !gameloader.isItOurTurn();
+	isPremove = !isOpponentPiece && !gameloader.isItOurTurn();
 
 	// Calculate the legal moves it has...
 

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -41,6 +41,7 @@ import space from '../../misc/space.js';
 import mouse from '../../../util/mouse.js';
 import gameslot from '../../chess/gameslot.js';
 import boardpos from '../boardpos.js';
+import movehints from '../highlights/movehints.js';
 import boardtiles from '../boardtiles.js';
 import primitives from '../primitives.js';
 import Transition from '../transitions/Transition.js';
@@ -54,7 +55,6 @@ import guinavigation from '../../gui/guinavigation.js';
 import instancedshapes from '../instancedshapes.js';
 import { listener_overlay } from '../../chess/game.js';
 import arrowlegalmovehighlights from './arrowlegalmovehighlights.js';
-import selectedpieceindividualmovehints from '../highlights/selectedpieceindividualmovehints.js';
 import { InputListener, Mouse, MouseButton } from '../../input.js';
 import {
 	createRenderable_Instanced,
@@ -1009,18 +1009,18 @@ function transitionTowardTargetIfClicked(
 
 /**
  * Computes and populates {@link hintArrows} for the current frame.
- * For each off-screen square returned by {@link selectedpieceindividualmovehints.getSquares},
+ * For each off-screen square returned by {@link movehints.getSquares},
  * creates a hint arrow at the nearest screen edge pointing toward that square.
  *
  * Respects the zoom threshold but ignores the current arrow mode,
  * so hint arrows are visible even when mode is 0 (off).
  */
 function updateHintArrows(): void {
-	const hintSquares = selectedpieceindividualmovehints.getSquares();
+	const hintSquares = movehints.getSquares();
 	if (hintSquares.length === 0) return;
 	if (!areZoomedInEnoughForArrows()) return;
 
-	const pieceCoords = selectedpieceindividualmovehints.getPieceCoords()!;
+	const pieceCoords = movehints.getPieceCoords()!;
 
 	const worldHalfWidth = getArrowIndicatorHalfWidth();
 	const pointerWorlds = mouse.getAllPointerWorlds();

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -1241,15 +1241,8 @@ function executeArrowShifts(): void {
 					? thisPieceIntersections[0]!.coords
 					: thisPieceIntersections[1]!.coords;
 
-				const arrow: Arrow = processPiece(
-					piece,
-					line,
-					intersect,
-					0,
-					worldHalfWidth,
-					pointerWorlds,
-					false,
-				);
+				// prettier-ignore
+				const arrow: Arrow = processPiece(piece, line, intersect, 0, worldHalfWidth, pointerWorlds, false);
 				const animatedArrow: AnimatedArrow = {
 					...arrow,
 					direction: line,

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -150,6 +150,16 @@ export interface Arrow extends BaseArrow {
 	piece: ArrowPiece;
 	/** Opacity to render this arrow at when not hovered. Defaults to the module-level opacity constant. */
 	opacity: number;
+	/**
+	 * The direction the arrow triangle points.
+	 * Equals `negateVector(processPiece vector)`, used directly as the render angle.
+	 */
+	direction: Vec2;
+	/**
+	 * Index within the adjacent-picture stack on this line. 0 for the primary (outermost)
+	 * indicator; > 0 for stacked indicators closer to the screen center.
+	 */
+	stackIndex: number;
 }
 
 /**
@@ -162,12 +172,6 @@ export interface ArrowPiece {
 	index: number;
 	/** Whether the piece is at a floating point coordinate. */
 	floating: boolean;
-}
-
-/** Animated piece arrows additionally carry their direction for rendering. */
-interface AnimatedArrow extends Arrow, BaseArrow {
-	/** Direction this indicator points, from the screen edge toward its target. */
-	direction: Vec2;
 }
 
 /** Hovered-arrow event: identifies which arrow indicator is currently being hovered. */
@@ -207,6 +211,8 @@ const lineCountToDisableArrows = 8;
 const WIDTH = 0.65;
 /** How much padding to include between the mini image of the pieces & arrows and the edge of the screen, in percentage of 1 tile. */
 const sidePadding = 0.15; // Default: 0.15   0.1 Lines up the tip of the arrows right against the edge
+/** The distance one arrow's picture's center should be from the screen edge. */
+const PADDING: BigDecimal = bd.fromNumber(WIDTH / 2 + sidePadding);
 /** How much separation between adjacent pictures pointing to multiple pieces on the same line, in percentage of 1 tile. */
 const paddingBetwAdjacentPictures = 0.35;
 /** Opacity of the mini images of the pieces and arrows. */
@@ -220,6 +226,34 @@ const perspectiveDist = 17;
 
 const ONE = bd.fromBigInt(1n);
 const HALF = bd.fromNumber(0.5);
+
+/**
+ * Attribute layout for the instanced piece-image renderable (arrow indicators).
+ * Defined once here to avoid re-allocating the object every frame.
+ */
+const ATTRIB_INFO_PICTURES: AttributeInfoInstanced = {
+	vertexDataAttribInfo: [
+		{ name: 'a_position', numComponents: 2 },
+		{ name: 'a_texturecoord', numComponents: 2 },
+	],
+	instanceDataAttribInfo: [
+		{ name: 'a_instanceposition', numComponents: 2 },
+		{ name: 'a_instancetexcoord', numComponents: 2 },
+		{ name: 'a_instancecolor', numComponents: 4 },
+	],
+};
+/**
+ * Attribute layout for the instanced arrow-triangle renderable.
+ * Defined once here to avoid re-allocating the object every frame.
+ */
+const ATTRIB_INFO_ARROWS: AttributeInfoInstanced = {
+	vertexDataAttribInfo: [{ name: 'a_position', numComponents: 2 }],
+	instanceDataAttribInfo: [
+		{ name: 'a_instanceposition', numComponents: 2 },
+		{ name: 'a_instancecolor', numComponents: 4 },
+		{ name: 'a_instancerotation', numComponents: 1 },
+	],
+};
 
 /**
  * The mode the arrow indicators on the edges of the screen is currently in.
@@ -264,7 +298,7 @@ let slideArrows: SlideArrows = {};
  * the piece captured being rendered in place.
  * Still animation's lines are recalculated manually.
  */
-const animatedArrows: AnimatedArrow[] = [];
+const animatedArrows: Arrow[] = [];
 
 /**
  * A list of all hint arrows computed for the current frame.
@@ -476,16 +510,10 @@ function updateBoundingBoxesOfVisibleScreen(): void {
 	 * Adds a little bit of padding to the bounding box, so that the arrows of the
 	 * arrows indicators aren't touching the edge of the screen.
 	 */
-	const padding: BigDecimal = getPadding();
-	boundingBoxFloat.left = bd.add(boundingBoxFloat.left, padding);
-	boundingBoxFloat.right = bd.subtract(boundingBoxFloat.right, padding);
-	boundingBoxFloat.bottom = bd.add(boundingBoxFloat.bottom, padding);
-	boundingBoxFloat.top = bd.subtract(boundingBoxFloat.top, padding);
-}
-
-/** Returns the distance one arrow's picture's center should be from the screen edge. */
-function getPadding(): BigDecimal {
-	return bd.fromNumber(WIDTH / 2 + sidePadding);
+	boundingBoxFloat.left = bd.add(boundingBoxFloat.left, PADDING);
+	boundingBoxFloat.right = bd.subtract(boundingBoxFloat.right, PADDING);
+	boundingBoxFloat.bottom = bd.add(boundingBoxFloat.bottom, PADDING);
+	boundingBoxFloat.top = bd.subtract(boundingBoxFloat.top, PADDING);
 }
 
 /**
@@ -655,7 +683,7 @@ function calcArrowsLineDraft(
 			firstIntersection.coords,
 		);
 		// Subtract the padding from the intersection so we get the distance to the intersection of the SCREEN EDGE.
-		firstIntersectionDist = bd.subtract(firstIntersectionDist, getPadding());
+		firstIntersectionDist = bd.subtract(firstIntersectionDist, PADDING);
 
 		// What is the distance to the farthest point this piece can slide along this direction?
 		let farthestSlidePoint: Coords | null;
@@ -830,7 +858,7 @@ function convertLineDraftToLine(
 	appendHover: boolean,
 ): ArrowsLine {
 	const negVector = vectors.negateVector(slideDir);
-	const boardsim = appendHover ? gameslot.getGamefile()!.boardsim : undefined;
+	const boardsim = gameslot.getGamefile()!.boardsim!;
 
 	const toArrow = (
 		dir: Vec2,
@@ -838,13 +866,20 @@ function convertLineDraftToLine(
 		arrowDraft: ArrowDraft,
 		index: number,
 	): Arrow => {
-		let ownsSlide = true;
-		if (boardsim !== undefined) {
-			const moveset = legalmoves.getPieceMoveset(boardsim, arrowDraft.piece.type);
-			ownsSlide = !!(moveset.sliding && moveset.sliding[vec2Key]);
-		}
 		// prettier-ignore
-		return processPiece(arrowDraft.piece, dir, intersection, index, worldHalfWidth, pointerWorlds, appendHover, ownsSlide);
+		const arrow = processPiece(arrowDraft.piece, dir, intersection, index, worldHalfWidth, pointerWorlds);
+		if (appendHover && arrow.hovered) {
+			const moveset = legalmoves.getPieceMoveset(boardsim, arrowDraft.piece.type);
+			const ownsSlide = !!(moveset.sliding && moveset.sliding[vec2Key]);
+
+			hoveredArrows.push({
+				piece: arrow.piece,
+				direction: arrow.direction,
+				worldLocation: arrow.worldLocation,
+				ownsSlide,
+			});
+		}
+		return arrow;
 	};
 
 	return {
@@ -870,14 +905,13 @@ function calculateSlideArrows_AndHovered(slideArrowsDraft: SlideArrowsDraft): vo
 	const worldHalfWidth = getArrowIndicatorHalfWidth();
 	const pointerWorlds = mouse.getAllPointerWorlds();
 
-	for (const [key, value] of Object.entries(slideArrowsDraft)) {
-		const vec2Key = key as Vec2Key;
-		const linesOfDirectionDraft = value as { [lineKey: string]: ArrowsLineDraft };
-		const slideDir = vectors.getVec2FromKey(vec2Key as Vec2Key);
+	for (const vec2Key of Object.keys(slideArrowsDraft) as Vec2Key[]) {
+		const linesOfDirectionDraft = slideArrowsDraft[vec2Key]!;
+		const slideDir = vectors.getVec2FromKey(vec2Key);
 		const linesOfDirection: { [lineKey: string]: ArrowsLine } = {};
 
-		for (const [lineKey, value] of Object.entries(linesOfDirectionDraft)) {
-			const arrowLineDraft = value as ArrowsLineDraft;
+		for (const lineKey of Object.keys(linesOfDirectionDraft)) {
+			const arrowLineDraft = linesOfDirectionDraft[lineKey]!;
 			// prettier-ignore
 			linesOfDirection[lineKey] = convertLineDraftToLine(arrowLineDraft, slideDir, vec2Key, worldHalfWidth, pointerWorlds, true);
 		}
@@ -895,23 +929,20 @@ function calculateSlideArrows_AndHovered(slideArrowsDraft: SlideArrowsDraft): vo
 /**
  * Calculates the detailed information about a single arrow indicator, enough to be able to render.
  * @param piece
- * @param vector - A vector pointing in the direction the arrow points.
+ * @param vector - A vector pointing TOWARD the piece (from screen edge outward). Used for adjacent-picture offsets and click transitions.
  * @param intersection - The intersection with the screen window that the line the piece is on intersects.
- * @param index - If there are adjacent pictures, this may be > 0
+ * @param stackIndex - If there are adjacent pictures, this may be > 0
  * @param worldHalfWidth
  * @param pointerWorlds - A list of all world coordinates every existing pointer is over.
- * @param appendHover - Whether the arrow, when hovered over, should add itself to the list of arrows hovered over this frame. Should be false for arrows added by other scripts.
  * @returns
  */
 function processPiece(
 	piece: ArrowPiece,
 	vector: Vec2,
 	intersection: BDCoords,
-	index: number,
+	stackIndex: number,
 	worldHalfWidth: number,
 	pointerWorlds: DoubleCoords[],
-	appendHover: boolean,
-	ownsSlide: boolean = true,
 ): Arrow {
 	const renderCoords = intersection; // Don't think we need to deep copy?
 
@@ -919,34 +950,23 @@ function processPiece(
 		space.convertCoordToWorldSpace_IgnoreSquareCenter(renderCoords);
 
 	// If this picture is an adjacent picture, adjust it's positioning
-	if (index > 0) {
+	if (stackIndex > 0) {
 		const scale = boardpos.getBoardScaleAsNumber();
-		worldLocation[0] += Number(vector[0]) * index * paddingBetwAdjacentPictures * scale;
-		worldLocation[1] += Number(vector[1]) * index * paddingBetwAdjacentPictures * scale;
+		worldLocation[0] += Number(vector[0]) * stackIndex * paddingBetwAdjacentPictures * scale;
+		worldLocation[1] += Number(vector[1]) * stackIndex * paddingBetwAdjacentPictures * scale;
 	}
 
 	// Does the mouse hover over the piece?
 	let hovered = false;
 	for (const pointerWorld of pointerWorlds) {
 		const chebyshevDist = vectors.chebyshevDistanceDoubles(worldLocation, pointerWorld);
-		if (chebyshevDist < worldHalfWidth) {
-			// Mouse inside the picture bounding box
-			hovered = true;
-			// ADD the piece to the list of arrows being hovered over!!!
-			// Convert direction the piece travels to reach arrow into the direction the arrow points, which is the OPPOSITE.
-			if (appendHover)
-				hoveredArrows.push({
-					piece,
-					direction: vectors.negateVector(vector),
-					worldLocation,
-					ownsSlide,
-				});
-		}
+		if (chebyshevDist < worldHalfWidth) hovered = true; // Mouse inside the picture bounding box
 	}
 	// Teleports toward the given piece if its arrow indicator is clicked this frame.
 	transitionTowardTargetIfClicked(piece.coords, vector, worldLocation, worldHalfWidth);
 
-	return { worldLocation, piece, hovered, opacity };
+	const direction = vectors.negateVector(vector);
+	return { worldLocation, piece, hovered, opacity, direction, stackIndex };
 }
 
 /**
@@ -1235,19 +1255,17 @@ function executeArrowShifts(): void {
 				if (thisPieceIntersections.length < 2) continue; // Slide direction doesn't intersect with screen box, no arrow needed
 
 				const positiveDotProduct = thisPieceIntersections[0]!.positiveDotProduct; // We know the dot product of both intersections will be identical, because the piece is off-screen.
-				if (positiveDotProduct) line = vectors.negateVector(line);
+				// Negate the vector if it is pointing AWAY from the screen (negative dot product side),
+				// so that `processPiece` always receives a vector pointing TOWARD the piece.
+				if (!positiveDotProduct) line = vectors.negateVector(line);
 				// At what point does it intersect the screen?
 				const intersect = positiveDotProduct
 					? thisPieceIntersections[0]!.coords
 					: thisPieceIntersections[1]!.coords;
 
 				// prettier-ignore
-				const arrow: Arrow = processPiece(piece, line, intersect, 0, worldHalfWidth, pointerWorlds, false);
-				const animatedArrow: AnimatedArrow = {
-					...arrow,
-					direction: line,
-				};
-				animatedArrows.push(animatedArrow);
+				const arrow: Arrow = processPiece(piece, line, intersect, 0, worldHalfWidth, pointerWorlds);
+				animatedArrows.push(arrow);
 			}
 		}
 	});
@@ -1384,31 +1402,16 @@ function render(): void {
 
 	// ADD THE DATA...
 
-	for (const [key, value] of Object.entries(slideArrows)) {
-		const vec2Key = key as Vec2Key;
-		const slideLinesOfDirection = value as { [lineKey: string]: ArrowsLine };
-
-		const slideDir = vectors.getVec2FromKey(vec2Key as Vec2Key);
-
-		// These are swamped so the arrow always points and the opposite direction the piece is able to slide.
-		const vector = vectors.negateVector(slideDir);
-		const negVector = slideDir;
-
-		for (const value of Object.values(slideLinesOfDirection)) {
-			const slideLine = value as ArrowsLine;
-
-			slideLine.posDotProd.forEach((arrow, index) =>
-				concatData(instanceData_Pictures, instanceData_Arrows, arrow, vector, index),
-			);
-			slideLine.negDotProd.forEach((arrow, index) =>
-				concatData(instanceData_Pictures, instanceData_Arrows, arrow, negVector, index),
-			);
+	for (const linesOfDirection of Object.values(slideArrows)) {
+		for (const line of Object.values(linesOfDirection) as ArrowsLine[]) {
+			for (const arrow of line.posDotProd)
+				concatData(instanceData_Pictures, instanceData_Arrows, arrow);
+			for (const arrow of line.negDotProd)
+				concatData(instanceData_Pictures, instanceData_Arrows, arrow);
 		}
 	}
-
-	// Add the animated arrows that are in motion
-	for (const pieceArrow of animatedArrows) {
-		concatData(instanceData_Pictures, instanceData_Arrows, pieceArrow, pieceArrow.direction, 0);
+	for (const arrow of animatedArrows) {
+		concatData(instanceData_Pictures, instanceData_Arrows, arrow);
 	}
 
 	// Render hint squares and triangles first (below piece images)
@@ -1459,26 +1462,11 @@ function render(): void {
 
 	// Render piece images for regular arrow indicators
 	if (instanceData_Pictures.length > 0) {
-		/*
-		 * The buffer model of the piece mini images on
-		 * the edge of the screen. **Doesn't include** the little arrows.
-		 */
-		const attribInfoInstancedPictures: AttributeInfoInstanced = {
-			vertexDataAttribInfo: [
-				{ name: 'a_position', numComponents: 2 },
-				{ name: 'a_texturecoord', numComponents: 2 },
-			],
-			instanceDataAttribInfo: [
-				{ name: 'a_instanceposition', numComponents: 2 },
-				{ name: 'a_instancetexcoord', numComponents: 2 },
-				{ name: 'a_instancecolor', numComponents: 4 },
-			],
-		};
 		const texture = spritesheet.getSpritesheet();
 		createRenderable_Instanced_GivenInfo(
 			vertexData_Pictures,
 			instanceData_Pictures,
-			attribInfoInstancedPictures,
+			ATTRIB_INFO_PICTURES,
 			'TRIANGLES',
 			'arrowImages',
 			[{ texture, uniformName: 'u_sampler' }],
@@ -1487,22 +1475,10 @@ function render(): void {
 
 	// Render all arrow direction triangles (regular piece arrows + hint arrows) together
 	if (instanceData_Arrows.length > 0) {
-		/*
-		 * The buffer model of the little arrows on
-		 * the edge of the screen next to the mini piece images.
-		 */
-		const attribInfoInstancedArrows: AttributeInfoInstanced = {
-			vertexDataAttribInfo: [{ name: 'a_position', numComponents: 2 }],
-			instanceDataAttribInfo: [
-				{ name: 'a_instanceposition', numComponents: 2 },
-				{ name: 'a_instancecolor', numComponents: 4 },
-				{ name: 'a_instancerotation', numComponents: 1 },
-			],
-		};
 		createRenderable_Instanced_GivenInfo(
 			vertexData_Arrows,
 			instanceData_Arrows,
-			attribInfoInstancedArrows,
+			ATTRIB_INFO_ARROWS,
 			'TRIANGLES',
 			'arrows',
 		).render();
@@ -1517,8 +1493,6 @@ function concatData(
 	instanceData_Pictures: number[],
 	instanceData_Arrows: number[],
 	arrow: Arrow,
-	vector: Vec2,
-	index: number,
 ): void {
 	/**
 	 * Our pictures' instance data needs to contain:
@@ -1533,16 +1507,12 @@ function concatData(
 	// Color
 	const a = arrow.hovered ? 1 : arrow.opacity;
 
-	// Opacity changing with distance
-	// let maxAxisDist = vectors.chebyshevDistance(boardpos.getBoardPos(), pieceCoords) - 8;
-	// opacity = Math.sin(maxAxisDist / 40) * 0.5
-
 	//							   instaceposition	   instancetexcoord  instancecolor
 	instanceData_Pictures.push(...arrow.worldLocation, ...thisTexLocation, 1, 1, 1, a);
 
 	// Next append the data of the little arrow!
 
-	if (index > 0) return; // We can skip, since it is an adjacent picture!
+	if (arrow.stackIndex > 0) return; // We can skip, since it is an adjacent picture!
 
 	/**
 	 * Our arrow's instance data needs to contain:
@@ -1552,9 +1522,9 @@ function concatData(
 	 * rotation offset (1 number)
 	 */
 
-	const vectorAsDoubles = vectors.convertVectorToDoubles(vector);
-	const angle = Math.atan2(vectorAsDoubles[1], vectorAsDoubles[0]); // Y value first
-	//								position		  color	 rotation
+	const dirAsDoubles = vectors.convertVectorToDoubles(arrow.direction);
+	const angle = Math.atan2(dirAsDoubles[1], dirAsDoubles[0]); // Y value first
+	//								position		   color	rotation
 	instanceData_Arrows.push(...arrow.worldLocation, 0, 0, 0, a, angle);
 }
 
@@ -1568,7 +1538,7 @@ function getVertexDataOfArrow(halfWorldWidth: number): number[] {
 	return [halfWorldWidth, -size, halfWorldWidth, size, halfWorldWidth + size, 0];
 }
 
-// ----------------------------------------------------------------------------------------------------------------
+// Exports -------------------------------------------------------------------------
 
 export default {
 	pieceCountToDisableArrows,

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -345,7 +345,7 @@ function getHoveredArrows(): HoveredArrow[] {
 }
 
 function areHoveringAtleastOneArrow(): boolean {
-	return hoveredArrows.length > 0;
+	return hoveredArrows.length > 0 || hintArrows.some((ha) => ha.hovered);
 }
 
 /**
@@ -1056,6 +1056,9 @@ function updateHintArrows(): void {
 		const hovered = pointerWorlds.some(
 			(p) => vectors.chebyshevDistanceDoubles(worldLocation, p) < worldHalfWidth,
 		);
+		// Prevent dragging the board when clicking on the move hint arrow.
+		if (hovered && mouse.isMouseDown(Mouse.LEFT)) mouse.claimMouseDown(Mouse.LEFT);
+
 		transitionTowardTargetIfClicked(hintSquareBD, direction, worldLocation, worldHalfWidth);
 
 		hintArrows.push({ worldLocation, direction, targetSquare: hintSquare, hovered });

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -10,6 +10,7 @@
  * Other scripts may add/remove arrows in between update() and render() calls.
  */
 
+import type { Color } from '../../../../../../shared/util/math/math.js';
 import type { Piece } from '../../../../../../shared/chess/util/boardutil.js';
 import type { Change } from '../../../../../../shared/chess/logic/boardchanges.js';
 import type { Board, FullGame } from '../../../../../../shared/chess/logic/gamefile.js';
@@ -47,6 +48,7 @@ import spritesheet from '../spritesheet.js';
 import guigameinfo from '../../gui/guigameinfo.js';
 import perspective from '../perspective.js';
 import preferences from '../../../components/header/preferences.js';
+import drawsquares from '../highlights/annotations/drawsquares.js';
 import frametracker from '../frametracker.js';
 import guinavigation from '../../gui/guinavigation.js';
 import instancedshapes from '../instancedshapes.js';
@@ -202,13 +204,15 @@ const pieceCountToDisableArrows = 40_000;
 const lineCountToDisableArrows = 8;
 
 /** The width of the mini images of the pieces and arrows, in percentage of 1 tile. */
-const width: number = 0.65;
+const PIECE_WIDTH = 0.65;
+/** The width of hint arrow indicators as a fraction of the normal arrow indicator width {@link PIECE_WIDTH}. */
+const HINT_WIDTH_FRACTION = 0.75;
 /** How much padding to include between the mini image of the pieces & arrows and the edge of the screen, in percentage of 1 tile. */
-const sidePadding: number = 0.15; // Default: 0.15   0.1 Lines up the tip of the arrows right against the edge
+const sidePadding = 0.15; // Default: 0.15   0.1 Lines up the tip of the arrows right against the edge
 /** How much separation between adjacent pictures pointing to multiple pieces on the same line, in percentage of 1 tile. */
-const paddingBetwAdjacentPictures: number = 0.35;
+const paddingBetwAdjacentPictures = 0.35;
 /** Opacity of the mini images of the pieces and arrows. */
-const opacity: number = 0.6;
+const opacity = 0.6;
 /** When we're zoomed out far enough that 1 tile is as wide as this many virtual pixels, we don't render the arrow indicators. */
 const renderZoomLimitVirtualPixels: BigDecimal = bd.fromBigInt(12n); // virtual pixels. Default: 20
 
@@ -367,7 +371,7 @@ function getAllArrowWorldLocations(): DoubleCoords[] {
  * This is the Chebyshev-distance radius used to detect hover/opacity changes.
  */
 function getArrowIndicatorHalfWidth(): number {
-	return (width * boardpos.getBoardScaleAsNumber()) / 2;
+	return (PIECE_WIDTH * boardpos.getBoardScaleAsNumber()) / 2;
 }
 
 // Updating -----------------------------------------------------------------------------------------------------------
@@ -494,7 +498,7 @@ function updateBoundingBoxesOfVisibleScreen(): void {
 
 /** Returns the distance one arrow's picture's center should be from the screen edge. */
 function getPadding(): BigDecimal {
-	return bd.fromNumber(width / 2 + sidePadding);
+	return bd.fromNumber(PIECE_WIDTH / 2 + sidePadding);
 }
 
 /**
@@ -1048,7 +1052,7 @@ function updateHintArrows(): void {
 
 	const pieceCoords = selectedpieceindividualmovehints.getPieceCoords()!;
 
-	const worldHalfWidth = getArrowIndicatorHalfWidth();
+	const worldHalfWidth = getArrowIndicatorHalfWidth() * HINT_WIDTH_FRACTION;
 	const pointerWorlds = mouse.getAllPointerWorlds();
 
 	for (const hintSquare of hintSquares) {
@@ -1504,6 +1508,8 @@ function regenerateModelAndRender(): void {
 			isPremove: false,
 		});
 
+		const size = worldHalfWidth * 2 * HINT_WIDTH_FRACTION;
+
 		// Green squares at screen edge for each hint arrow
 		const hintSquaresInstanceData: number[] = [];
 		for (const ha of hintArrows) hintSquaresInstanceData.push(...ha.worldLocation);
@@ -1513,21 +1519,31 @@ function regenerateModelAndRender(): void {
 			'TRIANGLES',
 			'highlights',
 			true,
-		).render(undefined, undefined, { u_size: worldHalfWidth * 2 });
+		).render(undefined, undefined, { u_size: size });
+
+		// Re-render hovered hint squares at full opacity on top
+		const hoveredHintSquaresInstanceData: number[] = [];
+		for (const ha of hintArrows) {
+			if (ha.hovered) hoveredHintSquaresInstanceData.push(...ha.worldLocation);
+		}
+		if (hoveredHintSquaresInstanceData.length > 0) {
+			const hoveredHintColor: Color = [...hintColor];
+			hoveredHintColor[3] = drawsquares.HOVER_OPACITY;
+			createRenderable_Instanced(
+				instancedshapes.getDataLegalMoveSquare(hoveredHintColor),
+				hoveredHintSquaresInstanceData,
+				'TRIANGLES',
+				'highlights',
+				true,
+			).render(undefined, undefined, { u_size: size });
+		}
 
 		// Append hint direction triangles into the shared arrow triangle array
 		for (const ha of hintArrows) {
 			const dirAsDoubles = vectors.convertVectorToDoubles(ha.direction);
 			const angle = Math.atan2(dirAsDoubles[1], dirAsDoubles[0]);
 			const a = ha.hovered ? 1 : opacity;
-			instanceData_Arrows.push(
-				...ha.worldLocation,
-				hintColor[0],
-				hintColor[1],
-				hintColor[2],
-				a,
-				angle,
-			);
+			instanceData_Arrows.push(...ha.worldLocation, 0, 0, 0, a, angle);
 		}
 	}
 

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -1008,34 +1008,6 @@ function transitionTowardTargetIfClicked(
 // Hint Arrows ----------------------------------------------------------------------------------------------------------------------------------
 
 /**
- * Given a coordinate lying off-screen and a direction toward the screen,
- * returns the world-space position of the near-side screen-edge intersection.
- * Returns undefined if no valid intersection exists.
- */
-function getOffscreenArrowWorldLocation(
-	coords: BDCoords,
-	direction: Vec2,
-): DoubleCoords | undefined {
-	const intersections = geometry.findLineBoxIntersectionsBD(coords, direction, boundingBoxFloat!);
-	if (intersections.length < 2) return undefined;
-	const nearSide = intersections[0]!.positiveDotProduct
-		? intersections[0]!.coords
-		: intersections[1]!.coords;
-	return space.convertCoordToWorldSpace_IgnoreSquareCenter(nearSide);
-}
-
-/** Returns true if any pointer is within worldHalfWidth of the given world location. */
-function isArrowHovered(
-	worldLocation: DoubleCoords,
-	worldHalfWidth: number,
-	pointerWorlds: DoubleCoords[],
-): boolean {
-	return pointerWorlds.some(
-		(p) => vectors.chebyshevDistanceDoubles(worldLocation, p) < worldHalfWidth,
-	);
-}
-
-/**
  * Computes and populates {@link hintArrows} for the current frame.
  * For each off-screen square returned by {@link selectedpieceindividualmovehints.getSquares},
  * creates a hint arrow at the nearest screen edge pointing toward that square.
@@ -1054,7 +1026,7 @@ function updateHintArrows(): void {
 	const pointerWorlds = mouse.getAllPointerWorlds();
 
 	for (const hintSquare of hintSquares) {
-		const sqBD = bdcoords.FromCoords(hintSquare);
+		const hintSquareBD = bdcoords.FromCoords(hintSquare);
 
 		// Skip if the hint square is already visible on screen
 		if (bounds.boxContainsSquare(boundingBoxInt!, hintSquare)) continue;
@@ -1062,13 +1034,29 @@ function updateHintArrows(): void {
 		// Direction from the selected piece toward the hint square
 		// const direction: Vec2 = vectors.normalizeVector([hintSquare[0] - pieceCoords[0], hintSquare[1] - pieceCoords[1]]);
 		const difference = coordutil.subtractCoords(hintSquare, pieceCoords);
-		const direction: Vec2 = vectors.normalizeVector(difference);
+		let direction: Vec2 = vectors.normalizeVector(difference);
 
-		const worldLocation = getOffscreenArrowWorldLocation(sqBD, direction);
-		if (worldLocation === undefined) continue;
+		// Calculate the world space position of the near-side screen edge intersection
+		// along the line from the piece to the hint square.
+		const intersections = geometry.findLineBoxIntersectionsBD(
+			hintSquareBD,
+			direction,
+			boundingBoxFloat!,
+		);
+		if (intersections.length < 2) continue;
+		const nearSide = intersections[0]!.positiveDotProduct
+			? intersections[0]!.coords
+			: intersections[1]!.coords;
+		const worldLocation = space.convertCoordToWorldSpace_IgnoreSquareCenter(nearSide);
 
-		const hovered = isArrowHovered(worldLocation, worldHalfWidth, pointerWorlds);
-		transitionTowardTargetIfClicked(sqBD, direction, worldLocation, worldHalfWidth);
+		// If we've panned past the hint square, flip the triangle so it still points toward the square
+		if (intersections[0]!.positiveDotProduct) direction = vectors.negateVector(direction);
+
+		// Whether any pointer is within worldHalfWidth of the given world location.
+		const hovered = pointerWorlds.some(
+			(p) => vectors.chebyshevDistanceDoubles(worldLocation, p) < worldHalfWidth,
+		);
+		transitionTowardTargetIfClicked(hintSquareBD, direction, worldLocation, worldHalfWidth);
 
 		hintArrows.push({ worldLocation, direction, targetSquare: hintSquare, hovered });
 	}

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -46,12 +46,18 @@ import Transition from '../transitions/Transition.js';
 import spritesheet from '../spritesheet.js';
 import guigameinfo from '../../gui/guigameinfo.js';
 import perspective from '../perspective.js';
+import preferences from '../../../components/header/preferences.js';
 import frametracker from '../frametracker.js';
 import guinavigation from '../../gui/guinavigation.js';
+import instancedshapes from '../instancedshapes.js';
 import { listener_overlay } from '../../chess/game.js';
 import arrowlegalmovehighlights from './arrowlegalmovehighlights.js';
+import selectedpieceindividualmovehints from '../highlights/selectedpieceindividualmovehints.js';
 import { InputListener, Mouse, MouseButton } from '../../input.js';
-import { createRenderable_Instanced_GivenInfo } from '../../../webgl/Renderable.js';
+import {
+	createRenderable_Instanced,
+	createRenderable_Instanced_GivenInfo,
+} from '../../../webgl/Renderable.js';
 
 // Types -------------------------------------------------------------------------------
 
@@ -129,12 +135,17 @@ interface ArrowsLine {
 	negDotProd: Arrow[];
 }
 
-/** A single arrow indicator, with enough information to be able to render it. */
-export interface Arrow {
+/** Shared base for all screen-edge arrow indicators. */
+interface BaseArrow {
+	/** The world-space position of this indicator on the screen edge. */
 	worldLocation: DoubleCoords;
-	piece: ArrowPiece;
-	/** Whether the arrow is being hovered over by the mouse */
+	/** Whether this indicator is being hovered over by the mouse. */
 	hovered: boolean;
+}
+
+/** A single piece-based arrow indicator, with enough information to be able to render it. */
+export interface Arrow extends BaseArrow {
+	piece: ArrowPiece;
 	/** Opacity to render this arrow at when not hovered. Defaults to the module-level opacity constant. */
 	opacity: number;
 }
@@ -151,21 +162,21 @@ export interface ArrowPiece {
 	floating: boolean;
 }
 
-/** Animated arrows are treated separately, we also need to know their direction. */
-interface AnimatedArrow extends Arrow {
+/** Animated piece arrows additionally carry their direction for rendering. */
+interface AnimatedArrow extends Arrow, BaseArrow {
+	/** Direction this indicator points, from the screen edge toward its target. */
 	direction: Vec2;
 }
 
-/** An arrow that is being hovered over this frame */
+/** Hovered-arrow event: identifies which arrow indicator is currently being hovered. */
 export interface HoveredArrow {
 	/** A reference to the piece it is pointing to */
 	piece: ArrowPiece;
 	/**
-	 * The slide direction / slope / step for this arrow.
-	 * Is the same as the direction the arrow is pointing.
-	 * Negated is auto-negated when applicable.
+	 * The direction this arrow points (from the screen edge toward the piece).
+	 * Matches the slide direction the arrow indicator represents.
 	 */
-	vector: Vec2;
+	direction: Vec2;
 	/** The world-space position of this arrow indicator on the screen edge. */
 	worldLocation: DoubleCoords;
 	/**
@@ -173,6 +184,14 @@ export interface HoveredArrow {
 	 * IS NOT calculated for shifted arrows (always true).
 	 */
 	ownsSlide: boolean;
+}
+
+/** An arrow indicator for an off-screen individual legal move, shown when in check. */
+interface HintArrow extends BaseArrow {
+	/** Direction this indicator points, from the screen edge toward its target. */
+	direction: Vec2;
+	/** The target square this hint arrow points to. */
+	targetSquare: Coords;
 }
 
 // Variables ----------------------------------------------------------------------------
@@ -245,6 +264,13 @@ let slideArrows: SlideArrows = {};
  */
 const animatedArrows: AnimatedArrow[] = [];
 
+/**
+ * A list of all hint arrows computed for the current frame.
+ * Each hints at an off-screen individual legal move destination.
+ * Reset each frame in reset().
+ */
+const hintArrows: HintArrow[] = [];
+
 // Utility ------------------------------------------------------------------------------
 
 /**
@@ -261,13 +287,14 @@ function reset(): void {
 	slideArrows = {};
 	animatedArrows.length = 0;
 	hoveredArrows.length = 0;
+	hintArrows.length = 0;
 	boundingBoxFloat = undefined;
 	boundingBoxInt = undefined;
 	shifts.length = 0;
 }
 
 /**
- * Sets the rendering mode of the arrow indicators on the edges of the screen.
+ * Sets the current mode of the arrow indicators.
  */
 function setMode(value: typeof mode): void {
 	mode = value;
@@ -358,11 +385,6 @@ function getArrowIndicatorHalfWidth(): number {
  */
 function update(): void {
 	reset(); // Initiate the arrows empty
-	if (!areArrowsActiveThisFrame()) {
-		// Arrow indicators are off, nothing is visible.
-		arrowlegalmovehighlights.reset(); // Also reset this
-		return;
-	}
 
 	/**
 	 * To be able to test if a piece is offscreen or not,
@@ -370,8 +392,19 @@ function update(): void {
 	 *
 	 * Even if a tiny portion of the square the piece is on
 	 * is visible on screen, we will not create an arrow for it.
+	 *
+	 * This is also needed for hint arrows, so it must be calculated
+	 * before the early return below.
 	 */
 	updateBoundingBoxesOfVisibleScreen();
+
+	updateHintArrows();
+
+	if (!areArrowsActiveThisFrame()) {
+		// Arrow indicators are off, nothing is visible.
+		arrowlegalmovehighlights.reset(); // Also reset this
+		return;
+	}
 
 	/**
 	 * Next, we are going to iterate through each slide existing in the game,
@@ -398,13 +431,18 @@ function update(): void {
 	calculateSlideArrows_AndHovered(slideArrowsDraft);
 }
 
-/** Whether the arrows should be calculated and rendered this frame */
+/**
+ * Whether the piece arrows should be calculated and rendered this frame.
+ * Excludes move hint arrows.
+ */
 function areArrowsActiveThisFrame(): boolean {
 	// false if the arrows are off, or if the board is too zoomed out
-	return (
-		mode !== 0 &&
-		bd.compare(boardtiles.gtileWidth_Pixels(false), renderZoomLimitVirtualPixels) >= 0
-	);
+	return mode !== 0 && areZoomedInEnoughForArrows();
+}
+
+/** Whether ANY arrow (piece or move hint) should be calculated and rendered this frame. */
+function areZoomedInEnoughForArrows(): boolean {
+	return bd.compare(boardtiles.gtileWidth_Pixels(false), renderZoomLimitVirtualPixels) >= 0;
 }
 
 /**
@@ -900,70 +938,137 @@ function processPiece(
 			if (appendHover)
 				hoveredArrows.push({
 					piece,
-					vector: vectors.negateVector(vector),
+					direction: vectors.negateVector(vector),
 					worldLocation,
 					ownsSlide,
 				});
 		}
 	}
-	// If we clicked, then teleport!
-	teleportToPieceIfClicked(piece, worldLocation, vector, worldHalfWidth);
+	// Teleports toward the given piece if its arrow indicator is clicked this frame.
+	transitionTowardTargetIfClicked(piece.coords, vector, worldLocation, worldHalfWidth);
 
 	return { worldLocation, piece, hovered, opacity };
 }
 
 /**
- * This teleports you to the piece it is pointing to IF the mouse has clicked it this frame.
+ * If a recognized click falls within worldHalfWidth of
+ * worldLocation, claims it and pans towards the target coordinates.
  */
-function teleportToPieceIfClicked(
-	piece: ArrowPiece,
-	pieceWorld: DoubleCoords,
-	vector: Vec2,
+function transitionTowardTargetIfClicked(
+	targetCoords: BDCoords,
+	direction: Vec2,
+	worldLocation: DoubleCoords,
 	worldHalfWidth: number,
 ): void {
+	let button: MouseButton;
+	let listener: typeof mouse | InputListener;
+
 	// Left mouse button
-	if (mouse.isMouseDown(Mouse.LEFT) || mouse.isMouseClicked(Mouse.LEFT))
-		processMouseClick(Mouse.LEFT, mouse);
+	if (mouse.isMouseClicked(Mouse.LEFT)) {
+		button = Mouse.LEFT;
+		listener = mouse;
+	}
 	// Finger simulating right mouse down (annotations mode ON)
 	else if (
-		(listener_overlay.isMouseDown(Mouse.RIGHT) ||
-			listener_overlay.isMouseClicked(Mouse.RIGHT)) &&
+		listener_overlay.isMouseClicked(Mouse.RIGHT) &&
 		listener_overlay.isMouseTouch(Mouse.RIGHT)
-	)
-		processMouseClick(Mouse.RIGHT, listener_overlay);
+	) {
+		button = Mouse.RIGHT;
+		listener = listener_overlay;
+	} else return; // No recognized click
 
-	function processMouseClick(button: MouseButton, listener: typeof mouse | InputListener): void {
-		const clickWorld = mouse.getMouseWorld(button);
-		if (!clickWorld) return; // Maybe we're looking into sky?
-		const chebyshevDist = vectors.chebyshevDistanceDoubles(pieceWorld, clickWorld);
-		if (chebyshevDist < worldHalfWidth) {
-			// Mouse inside the picture bounding box
-			if (listener.isMouseClicked(button)) {
-				listener.claimMouseClick(button); // Don't let annotations erase/draw
+	const clickWorld = mouse.getMouseWorld(button);
+	if (!clickWorld) return; // Maybe we're looking into sky?
+	if (vectors.chebyshevDistanceDoubles(worldLocation, clickWorld) >= worldHalfWidth) return;
+	// Mouse is inside the picture bounding box...
+	listener.claimMouseClick(button); // Don't let annotations erase/draw
 
-				// Teleport in the direction of the piece's arrow, NOT straight to the piece.
+	// Pan along parallel direction to the perpendicular foot of targetCoords, NOT straight to the piece.
 
-				const startCoords = boardpos.getBoardPos();
-				// The direction we will follow when teleporting
-				const line1GeneralForm = vectors.getLineGeneralFormFromCoordsAndVecBD(
-					startCoords,
-					vector,
-				);
-				// The line perpendicular to the target piece === The Normal
-				const perpendicularSlideDir: Vec2 = vectors.getPerpendicularVector(vector);
-				const line2GeneralForm = vectors.getLineGeneralFormFromCoordsAndVecBD(
-					piece.coords,
-					perpendicularSlideDir,
-				);
-				// The target teleport coords
-				const telCoords = geometry.calcIntersectionPointOfLinesBD(
-					...line1GeneralForm,
-					...line2GeneralForm,
-				)!; // We know it will be defined because they are PERPENDICULAR
+	const startCoords = boardpos.getBoardPos();
+	// The direction we will follow when teleporting
+	const line1GeneralForm = vectors.getLineGeneralFormFromCoordsAndVecBD(startCoords, direction);
+	// The line perpendicular to the target piece === The Normal
+	const perpendicularSlideDir: Vec2 = vectors.getPerpendicularVector(direction);
+	const line2GeneralForm = vectors.getLineGeneralFormFromCoordsAndVecBD(
+		targetCoords,
+		perpendicularSlideDir,
+	);
+	// The target teleport coords
+	const telCoords = geometry.calcIntersectionPointOfLinesBD(
+		...line1GeneralForm,
+		...line2GeneralForm,
+	)!; // We know it will be defined because they are PERPENDICULAR
 
-				Transition.startPanTransition(telCoords, false);
-			} // Mouse down claiming is now the responsibility of dragarrows.ts
-		}
+	Transition.startPanTransition(telCoords, false);
+}
+
+// Hint Arrows ----------------------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Given a coordinate lying off-screen and a direction toward the screen,
+ * returns the world-space position of the near-side screen-edge intersection.
+ * Returns undefined if no valid intersection exists.
+ */
+function getOffscreenArrowWorldLocation(
+	coords: BDCoords,
+	direction: Vec2,
+): DoubleCoords | undefined {
+	const intersections = geometry.findLineBoxIntersectionsBD(coords, direction, boundingBoxFloat!);
+	if (intersections.length < 2) return undefined;
+	const nearSide = intersections[0]!.positiveDotProduct
+		? intersections[0]!.coords
+		: intersections[1]!.coords;
+	return space.convertCoordToWorldSpace_IgnoreSquareCenter(nearSide);
+}
+
+/** Returns true if any pointer is within worldHalfWidth of the given world location. */
+function isArrowHovered(
+	worldLocation: DoubleCoords,
+	worldHalfWidth: number,
+	pointerWorlds: DoubleCoords[],
+): boolean {
+	return pointerWorlds.some(
+		(p) => vectors.chebyshevDistanceDoubles(worldLocation, p) < worldHalfWidth,
+	);
+}
+
+/**
+ * Computes and populates {@link hintArrows} for the current frame.
+ * For each off-screen square returned by {@link selectedpieceindividualmovehints.getSquares},
+ * creates a hint arrow at the nearest screen edge pointing toward that square.
+ *
+ * Respects the zoom threshold but ignores the current arrow mode,
+ * so hint arrows are visible even when mode is 0 (off).
+ */
+function updateHintArrows(): void {
+	const hintSquares = selectedpieceindividualmovehints.getSquares();
+	if (hintSquares.length === 0) return;
+	if (!areZoomedInEnoughForArrows()) return;
+
+	const pieceCoords = selectedpieceindividualmovehints.getPieceCoords()!;
+
+	const worldHalfWidth = getArrowIndicatorHalfWidth();
+	const pointerWorlds = mouse.getAllPointerWorlds();
+
+	for (const hintSquare of hintSquares) {
+		const sqBD = bdcoords.FromCoords(hintSquare);
+
+		// Skip if the hint square is already visible on screen
+		if (bounds.boxContainsSquare(boundingBoxInt!, hintSquare)) continue;
+
+		// Direction from the selected piece toward the hint square
+		// const direction: Vec2 = vectors.normalizeVector([hintSquare[0] - pieceCoords[0], hintSquare[1] - pieceCoords[1]]);
+		const difference = coordutil.subtractCoords(hintSquare, pieceCoords);
+		const direction: Vec2 = vectors.normalizeVector(difference);
+
+		const worldLocation = getOffscreenArrowWorldLocation(sqBD, direction);
+		if (worldLocation === undefined) continue;
+
+		const hovered = isArrowHovered(worldLocation, worldHalfWidth, pointerWorlds);
+		transitionTowardTargetIfClicked(sqBD, direction, worldLocation, worldHalfWidth);
+
+		hintArrows.push({ worldLocation, direction, targetSquare: hintSquare, hovered });
 	}
 }
 
@@ -1308,7 +1413,12 @@ function render(): void {
 }
 
 function regenerateModelAndRender(): void {
-	if (Object.keys(slideArrows).length === 0 && animatedArrows.length === 0) return; // No visible arrows, don't generate the model
+	if (
+		Object.keys(slideArrows).length === 0 &&
+		animatedArrows.length === 0 &&
+		hintArrows.length === 0
+	)
+		return; // No visible arrows, don't generate the model
 
 	const worldHalfWidth = getArrowIndicatorHalfWidth();
 
@@ -1359,53 +1469,90 @@ function regenerateModelAndRender(): void {
 		concatData(instanceData_Pictures, instanceData_Arrows, pieceArrow, pieceArrow.direction, 0);
 	}
 
-	/*
-	 * The buffer model of the piece mini images on
-	 * the edge of the screen. **Doesn't include** the little arrows.
-	 */
-	const attribInfoInstancedPictures: AttributeInfoInstanced = {
-		vertexDataAttribInfo: [
-			{ name: 'a_position', numComponents: 2 },
-			{ name: 'a_texturecoord', numComponents: 2 },
-		],
-		instanceDataAttribInfo: [
-			{ name: 'a_instanceposition', numComponents: 2 },
-			{ name: 'a_instancetexcoord', numComponents: 2 },
-			{ name: 'a_instancecolor', numComponents: 4 },
-		],
-	};
-	const texture = spritesheet.getSpritesheet();
-	const modelPictures = createRenderable_Instanced_GivenInfo(
-		vertexData_Pictures,
-		instanceData_Pictures,
-		attribInfoInstancedPictures,
-		'TRIANGLES',
-		'arrowImages',
-		[{ texture, uniformName: 'u_sampler' }],
-	);
+	// Render piece images for regular arrow indicators
+	if (instanceData_Pictures.length > 0) {
+		/*
+		 * The buffer model of the piece mini images on
+		 * the edge of the screen. **Doesn't include** the little arrows.
+		 */
+		const attribInfoInstancedPictures: AttributeInfoInstanced = {
+			vertexDataAttribInfo: [
+				{ name: 'a_position', numComponents: 2 },
+				{ name: 'a_texturecoord', numComponents: 2 },
+			],
+			instanceDataAttribInfo: [
+				{ name: 'a_instanceposition', numComponents: 2 },
+				{ name: 'a_instancetexcoord', numComponents: 2 },
+				{ name: 'a_instancecolor', numComponents: 4 },
+			],
+		};
+		const texture = spritesheet.getSpritesheet();
+		createRenderable_Instanced_GivenInfo(
+			vertexData_Pictures,
+			instanceData_Pictures,
+			attribInfoInstancedPictures,
+			'TRIANGLES',
+			'arrowImages',
+			[{ texture, uniformName: 'u_sampler' }],
+		).render();
+	}
 
-	/*
-	 * The buffer model of the little arrows on
-	 * the edge of the screen next to the mini piece images.
-	 */
-	const attribInfoInstancedArrows: AttributeInfoInstanced = {
-		vertexDataAttribInfo: [{ name: 'a_position', numComponents: 2 }],
-		instanceDataAttribInfo: [
-			{ name: 'a_instanceposition', numComponents: 2 },
-			{ name: 'a_instancecolor', numComponents: 4 },
-			{ name: 'a_instancerotation', numComponents: 1 },
-		],
-	};
-	const modelArrows = createRenderable_Instanced_GivenInfo(
-		vertexData_Arrows,
-		instanceData_Arrows,
-		attribInfoInstancedArrows,
-		'TRIANGLES',
-		'arrows',
-	);
+	// Render hint squares and append hint direction triangles to the shared arrow triangle array
+	if (hintArrows.length > 0) {
+		const hintColor = preferences.getLegalMoveHighlightColor({
+			isOpponentPiece: false,
+			isPremove: false,
+		});
 
-	modelPictures.render();
-	modelArrows.render();
+		// Green squares at screen edge for each hint arrow
+		const hintSquaresInstanceData: number[] = [];
+		for (const ha of hintArrows) hintSquaresInstanceData.push(...ha.worldLocation);
+		createRenderable_Instanced(
+			instancedshapes.getDataLegalMoveSquare(hintColor),
+			hintSquaresInstanceData,
+			'TRIANGLES',
+			'highlights',
+			true,
+		).render(undefined, undefined, { u_size: worldHalfWidth * 2 });
+
+		// Append hint direction triangles into the shared arrow triangle array
+		for (const ha of hintArrows) {
+			const dirAsDoubles = vectors.convertVectorToDoubles(ha.direction);
+			const angle = Math.atan2(dirAsDoubles[1], dirAsDoubles[0]);
+			const a = ha.hovered ? 1 : opacity;
+			instanceData_Arrows.push(
+				...ha.worldLocation,
+				hintColor[0],
+				hintColor[1],
+				hintColor[2],
+				a,
+				angle,
+			);
+		}
+	}
+
+	// Render all arrow direction triangles (regular piece arrows + hint arrows) together
+	if (instanceData_Arrows.length > 0) {
+		/*
+		 * The buffer model of the little arrows on
+		 * the edge of the screen next to the mini piece images.
+		 */
+		const attribInfoInstancedArrows: AttributeInfoInstanced = {
+			vertexDataAttribInfo: [{ name: 'a_position', numComponents: 2 }],
+			instanceDataAttribInfo: [
+				{ name: 'a_instanceposition', numComponents: 2 },
+				{ name: 'a_instancecolor', numComponents: 4 },
+				{ name: 'a_instancerotation', numComponents: 1 },
+			],
+		};
+		createRenderable_Instanced_GivenInfo(
+			vertexData_Arrows,
+			instanceData_Arrows,
+			attribInfoInstancedArrows,
+			'TRIANGLES',
+			'arrows',
+		).render();
+	}
 }
 
 /**

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -204,9 +204,7 @@ const pieceCountToDisableArrows = 40_000;
 const lineCountToDisableArrows = 8;
 
 /** The width of the mini images of the pieces and arrows, in percentage of 1 tile. */
-const PIECE_WIDTH = 0.65;
-/** The width of hint arrow indicators as a fraction of the normal arrow indicator width {@link PIECE_WIDTH}. */
-const HINT_WIDTH_FRACTION = 0.75;
+const WIDTH = 0.65;
 /** How much padding to include between the mini image of the pieces & arrows and the edge of the screen, in percentage of 1 tile. */
 const sidePadding = 0.15; // Default: 0.15   0.1 Lines up the tip of the arrows right against the edge
 /** How much separation between adjacent pictures pointing to multiple pieces on the same line, in percentage of 1 tile. */
@@ -371,7 +369,7 @@ function getAllArrowWorldLocations(): DoubleCoords[] {
  * This is the Chebyshev-distance radius used to detect hover/opacity changes.
  */
 function getArrowIndicatorHalfWidth(): number {
-	return (PIECE_WIDTH * boardpos.getBoardScaleAsNumber()) / 2;
+	return (WIDTH * boardpos.getBoardScaleAsNumber()) / 2;
 }
 
 // Updating -----------------------------------------------------------------------------------------------------------
@@ -498,7 +496,7 @@ function updateBoundingBoxesOfVisibleScreen(): void {
 
 /** Returns the distance one arrow's picture's center should be from the screen edge. */
 function getPadding(): BigDecimal {
-	return bd.fromNumber(PIECE_WIDTH / 2 + sidePadding);
+	return bd.fromNumber(WIDTH / 2 + sidePadding);
 }
 
 /**
@@ -1052,7 +1050,7 @@ function updateHintArrows(): void {
 
 	const pieceCoords = selectedpieceindividualmovehints.getPieceCoords()!;
 
-	const worldHalfWidth = getArrowIndicatorHalfWidth() * HINT_WIDTH_FRACTION;
+	const worldHalfWidth = getArrowIndicatorHalfWidth();
 	const pointerWorlds = mouse.getAllPointerWorlds();
 
 	for (const hintSquare of hintSquares) {
@@ -1473,6 +1471,52 @@ function regenerateModelAndRender(): void {
 		concatData(instanceData_Pictures, instanceData_Arrows, pieceArrow, pieceArrow.direction, 0);
 	}
 
+	// Render hint squares and triangles first (below piece images)
+	if (hintArrows.length > 0) {
+		const hintColor = preferences.getLegalMoveHighlightColor({
+			isOpponentPiece: false,
+			isPremove: false,
+		});
+
+		const size = worldHalfWidth * 2;
+
+		// Green squares at screen edge for each hint arrow
+		const hintSquaresInstanceData: number[] = [];
+		for (const ha of hintArrows) hintSquaresInstanceData.push(...ha.worldLocation);
+		createRenderable_Instanced(
+			instancedshapes.getDataLegalMoveSquare(hintColor),
+			hintSquaresInstanceData,
+			'TRIANGLES',
+			'highlights',
+			true,
+		).render(undefined, undefined, { u_size: size });
+
+		// Re-render hovered hint squares at increased opacity on top
+		const hoveredHintSquaresInstanceData: number[] = [];
+		for (const ha of hintArrows) {
+			if (ha.hovered) hoveredHintSquaresInstanceData.push(...ha.worldLocation);
+		}
+		if (hoveredHintSquaresInstanceData.length > 0) {
+			const hoveredHintColor: Color = [...hintColor];
+			hoveredHintColor[3] = drawsquares.HOVER_OPACITY;
+			createRenderable_Instanced(
+				instancedshapes.getDataLegalMoveSquare(hoveredHintColor),
+				hoveredHintSquaresInstanceData,
+				'TRIANGLES',
+				'highlights',
+				true,
+			).render(undefined, undefined, { u_size: size });
+		}
+
+		// Append hint direction triangles into the shared arrow triangle array
+		for (const ha of hintArrows) {
+			const dirAsDoubles = vectors.convertVectorToDoubles(ha.direction);
+			const angle = Math.atan2(dirAsDoubles[1], dirAsDoubles[0]);
+			const a = ha.hovered ? 1 : opacity;
+			instanceData_Arrows.push(...ha.worldLocation, 0, 0, 0, a, angle);
+		}
+	}
+
 	// Render piece images for regular arrow indicators
 	if (instanceData_Pictures.length > 0) {
 		/*
@@ -1499,52 +1543,6 @@ function regenerateModelAndRender(): void {
 			'arrowImages',
 			[{ texture, uniformName: 'u_sampler' }],
 		).render();
-	}
-
-	// Render hint squares and append hint direction triangles to the shared arrow triangle array
-	if (hintArrows.length > 0) {
-		const hintColor = preferences.getLegalMoveHighlightColor({
-			isOpponentPiece: false,
-			isPremove: false,
-		});
-
-		const size = worldHalfWidth * 2 * HINT_WIDTH_FRACTION;
-
-		// Green squares at screen edge for each hint arrow
-		const hintSquaresInstanceData: number[] = [];
-		for (const ha of hintArrows) hintSquaresInstanceData.push(...ha.worldLocation);
-		createRenderable_Instanced(
-			instancedshapes.getDataLegalMoveSquare(hintColor),
-			hintSquaresInstanceData,
-			'TRIANGLES',
-			'highlights',
-			true,
-		).render(undefined, undefined, { u_size: size });
-
-		// Re-render hovered hint squares at full opacity on top
-		const hoveredHintSquaresInstanceData: number[] = [];
-		for (const ha of hintArrows) {
-			if (ha.hovered) hoveredHintSquaresInstanceData.push(...ha.worldLocation);
-		}
-		if (hoveredHintSquaresInstanceData.length > 0) {
-			const hoveredHintColor: Color = [...hintColor];
-			hoveredHintColor[3] = drawsquares.HOVER_OPACITY;
-			createRenderable_Instanced(
-				instancedshapes.getDataLegalMoveSquare(hoveredHintColor),
-				hoveredHintSquaresInstanceData,
-				'TRIANGLES',
-				'highlights',
-				true,
-			).render(undefined, undefined, { u_size: size });
-		}
-
-		// Append hint direction triangles into the shared arrow triangle array
-		for (const ha of hintArrows) {
-			const dirAsDoubles = vectors.convertVectorToDoubles(ha.direction);
-			const angle = Math.atan2(dirAsDoubles[1], dirAsDoubles[0]);
-			const a = ha.hovered ? 1 : opacity;
-			instanceData_Arrows.push(...ha.worldLocation, 0, 0, 0, a, angle);
-		}
 	}
 
 	// Render all arrow direction triangles (regular piece arrows + hint arrows) together

--- a/src/client/scripts/esm/game/rendering/arrows/arrows.ts
+++ b/src/client/scripts/esm/game/rendering/arrows/arrows.ts
@@ -353,15 +353,7 @@ function areHoveringAtleastOneArrow(): boolean {
  * Must be called after update().
  */
 function getAllArrowWorldLocations(): DoubleCoords[] {
-	const locations: DoubleCoords[] = [];
-	for (const linesOfDirection of Object.values(slideArrows)) {
-		for (const line of Object.values(linesOfDirection as { [lineKey: string]: ArrowsLine })) {
-			for (const arrow of line.posDotProd) locations.push(arrow.worldLocation);
-			for (const arrow of line.negDotProd) locations.push(arrow.worldLocation);
-		}
-	}
-	for (const arrow of animatedArrows) locations.push(arrow.worldLocation);
-	return locations;
+	return [...getAllArrows(), ...animatedArrows].map((a) => a.worldLocation);
 }
 
 /**
@@ -417,10 +409,7 @@ function update(): void {
 	 */
 
 	/** The object that stores all arrows that should be visible this frame. */
-	const slideArrowsDraft: SlideArrowsDraft = generateArrowsDraft(
-		boundingBoxInt!,
-		boundingBoxFloat!,
-	);
+	const slideArrowsDraft: SlideArrowsDraft = generateArrowsDraft();
 
 	// Remove arrows based on our mode
 	removeUnnecessaryArrows(slideArrowsDraft);
@@ -503,10 +492,7 @@ function getPadding(): BigDecimal {
  * Generates a draft of all the arrows for a game, as if All (plus hippogonals) mode was on.
  * This contains minimal information, as some may be removed later.
  */
-function generateArrowsDraft(
-	boundingBoxInt: BoundingBox,
-	boundingBoxFloat: BoundingBoxBD,
-): SlideArrowsDraft {
+function generateArrowsDraft(): SlideArrowsDraft {
 	/** The running list of arrows that should be visible */
 	const slideArrowsDraft: SlideArrowsDraft = {};
 	const gamefile = gameslot.getGamefile()!;
@@ -518,7 +504,7 @@ function generateArrowsDraft(
 		// that will contain all organized lines of the given vector
 		// intersecting the box between them.
 
-		const containingPoints = geometry.findCrossSectionalWidthPoints(slide, boundingBoxInt);
+		const containingPoints = geometry.findCrossSectionalWidthPoints(slide, boundingBoxInt!);
 		const containingPointsLineC = containingPoints.map((point) =>
 			vectors.getLineCFromCoordsAndVec(point, slide),
 		) as [bigint, bigint];
@@ -538,14 +524,7 @@ function generateArrowsDraft(
 				continue; // Next line, this one is off-screen, so no piece arrows are visible
 
 			// Calculate the ACTUAL arrows that should be visible for this specific organized line.
-			const arrowsLine = calcArrowsLineDraft(
-				gamefile,
-				boundingBoxInt,
-				boundingBoxFloat,
-				slide,
-				slideKey,
-				organizedLine,
-			);
+			const arrowsLine = calcArrowsLineDraft(gamefile, slide, slideKey, organizedLine);
 			if (arrowsLine === undefined) continue;
 			if (!slideArrowsDraft[slideKey]) slideArrowsDraft[slideKey] = {}; // Make sure this exists first
 			slideArrowsDraft[slideKey][lineKey] = arrowsLine; // Add this arrows line to our object containing all arrows for this frame
@@ -565,8 +544,6 @@ function generateArrowsDraft(
  */
 function calcArrowsLineDraft(
 	gamefile: FullGame,
-	boundingBoxInt: BoundingBox,
-	boundingBoxFloat: BoundingBoxBD,
 	slideDir: Vec2,
 	slideKey: Vec2Key,
 	organizedline: number[],
@@ -592,10 +569,12 @@ function calcArrowsLineDraft(
 		.findLineBoxIntersectionsBD(
 			bdcoords.FromCoords(firstPiece.coords),
 			slideDir,
-			boundingBoxFloat,
+			boundingBoxFloat!,
 		)
 		.map((c) => c.coords);
 	if (intersections.length < 2) return; // Arrow line intersected screen box exactly on the corner!! Let's skip constructing this line. No arrow will be visible
+
+	const boundingBoxIntBD = bounds.castBoundingBoxToBigDecimal(boundingBoxInt!);
 
 	organizedline.forEach((idx) => {
 		const piece = boardutil.getPieceFromIdx(gamefile.boardsim.pieces, idx)!;
@@ -607,7 +586,6 @@ function calcArrowsLineDraft(
 		};
 
 		// Is the piece off-screen?
-		const boundingBoxIntBD = bounds.castBoundingBoxToBigDecimal(boundingBoxInt);
 		if (bounds.boxContainsSquareBD(boundingBoxIntBD, arrowPiece.coords)) return; // On-screen, no arrow needed
 
 		// Piece is guaranteed off-screen...
@@ -616,7 +594,7 @@ function calcArrowsLineDraft(
 		const thisPieceIntersections = geometry.findLineBoxIntersectionsBD(
 			arrowPiece.coords,
 			slideDir,
-			boundingBoxFloat,
+			boundingBoxFloat!,
 		);
 		if (thisPieceIntersections.length < 2) return;
 		const positiveDotProduct = thisPieceIntersections[0]!.positiveDotProduct; // We know the dot product of both intersections will be identical, because the piece is off-screen.
@@ -839,6 +817,47 @@ function removeTypesThatCantSlideOntoScreenFromLineDraft(line: ArrowsLineDraft):
 }
 
 /**
+ * Converts an {@link ArrowsLineDraft} into a fully computed {@link ArrowsLine},
+ * resolving world-space positions and hover detection for each arrow.
+ * When appendHover is true, also computes ownsSlide and registers hovered arrows.
+ */
+function convertLineDraftToLine(
+	draft: ArrowsLineDraft,
+	slideDir: Vec2,
+	vec2Key: Vec2Key,
+	worldHalfWidth: number,
+	pointerWorlds: DoubleCoords[],
+	appendHover: boolean,
+): ArrowsLine {
+	const negVector = vectors.negateVector(slideDir);
+	const boardsim = appendHover ? gameslot.getGamefile()!.boardsim : undefined;
+
+	const toArrow = (
+		dir: Vec2,
+		intersection: BDCoords,
+		arrowDraft: ArrowDraft,
+		index: number,
+	): Arrow => {
+		let ownsSlide = true;
+		if (boardsim !== undefined) {
+			const moveset = legalmoves.getPieceMoveset(boardsim, arrowDraft.piece.type);
+			ownsSlide = !!(moveset.sliding && moveset.sliding[vec2Key]);
+		}
+		// prettier-ignore
+		return processPiece(arrowDraft.piece, dir, intersection, index, worldHalfWidth, pointerWorlds, appendHover, ownsSlide);
+	};
+
+	return {
+		posDotProd: draft.posDotProd.map((ad, i) =>
+			toArrow(slideDir, draft.intersections[0], ad, i),
+		),
+		negDotProd: draft.negDotProd.map((ad, i) =>
+			toArrow(negVector, draft.intersections[1], ad, i),
+		),
+	};
+}
+
+/**
  * Calculates the more detailed information of the visible arrow indicators this frame,
  * enough so we are able to render them.
  *
@@ -848,41 +867,19 @@ function calculateSlideArrows_AndHovered(slideArrowsDraft: SlideArrowsDraft): vo
 	if (Object.keys(slideArrows).length > 0)
 		throw Error('SHOULD have erased all slide arrows before recalcing');
 
-	const boardsim = gameslot.getGamefile()!.boardsim;
 	const worldHalfWidth = getArrowIndicatorHalfWidth();
 	const pointerWorlds = mouse.getAllPointerWorlds();
 
-	// Take the arrows draft, construct the actual
 	for (const [key, value] of Object.entries(slideArrowsDraft)) {
 		const vec2Key = key as Vec2Key;
 		const linesOfDirectionDraft = value as { [lineKey: string]: ArrowsLineDraft };
-
 		const slideDir = vectors.getVec2FromKey(vec2Key as Vec2Key);
 		const linesOfDirection: { [lineKey: string]: ArrowsLine } = {};
 
-		const vector = slideDir;
-		const negVector = vectors.negateVector(slideDir);
-
 		for (const [lineKey, value] of Object.entries(linesOfDirectionDraft)) {
 			const arrowLineDraft = value as ArrowsLineDraft;
-
-			const posDotProd: Arrow[] = [];
-			const negDotProd: Arrow[] = [];
-
-			for (const [drafts, dir, intersection, output] of [
-				[arrowLineDraft.posDotProd, vector, arrowLineDraft.intersections[0], posDotProd],
-				[arrowLineDraft.negDotProd, negVector, arrowLineDraft.intersections[1], negDotProd],
-			] as [ArrowDraft[], Vec2, BDCoords, Arrow[]][]) {
-				drafts.forEach((arrowDraft, index) => {
-					const moveset = legalmoves.getPieceMoveset(boardsim, arrowDraft.piece.type);
-					// Whether this piece can slide in the direction of the arrow
-					const ownsSlide = !!(moveset.sliding && moveset.sliding[vec2Key]);
-					// prettier-ignore
-					output.push(processPiece(arrowDraft.piece, dir, intersection, index, worldHalfWidth, pointerWorlds, true, ownsSlide));
-				});
-			}
-
-			linesOfDirection[lineKey] = { posDotProd, negDotProd };
+			// prettier-ignore
+			linesOfDirection[lineKey] = convertLineDraftToLine(arrowLineDraft, slideDir, vec2Key, worldHalfWidth, pointerWorlds, true);
 		}
 
 		slideArrows[vec2Key] = linesOfDirection;
@@ -1180,6 +1177,7 @@ function executeArrowShifts(): void {
 
 	const worldHalfWidth = getArrowIndicatorHalfWidth(); // The world-space width of our images
 	const pointerWorlds = mouse.getAllPointerWorlds();
+	const slideExceptions = getSlideExceptions();
 
 	shifts.forEach((shift) => {
 		// { type: string, index?: number } & ({ start: Coords, end?: Coords } | { start?: Coords, end: Coords });
@@ -1286,11 +1284,13 @@ function executeArrowShifts(): void {
 	shifts.forEach((shift) => {
 		if (shift.kind === 'delete' || shift.kind === 'move' || shift.kind === 'animate') {
 			// Recalculate the lines through the start coordinate
-			recalculateLinesThroughCoords(gamefile, shift.start);
+			// prettier-ignore
+			recalculateLinesThroughCoords(gamefile, shift.start, worldHalfWidth, pointerWorlds, slideExceptions);
 		}
 		if (shift.kind === 'add' || shift.kind === 'move') {
 			// Recalculate the lines through the end coordinate
-			recalculateLinesThroughCoords(gamefile, shift.end);
+			// prettier-ignore
+			recalculateLinesThroughCoords(gamefile, shift.end, worldHalfWidth, pointerWorlds, slideExceptions);
 		}
 	});
 
@@ -1305,7 +1305,13 @@ function executeArrowShifts(): void {
  * Recalculates all of the arrow lines the given piece
  * is on, adding them to this frame's list of arrows.
  */
-function recalculateLinesThroughCoords(gamefile: FullGame, coords: Coords): void {
+function recalculateLinesThroughCoords(
+	gamefile: FullGame,
+	coords: Coords,
+	worldHalfWidth: number,
+	pointerWorlds: DoubleCoords[],
+	slideExceptions: Vec2Key[],
+): void {
 	// console.log("Recalculating lines through coords: ", coords);
 	// Recalculate every single line it is on.
 
@@ -1331,65 +1337,19 @@ function recalculateLinesThroughCoords(gamefile: FullGame, coords: Coords): void
 		const organizedLine = linegroup.get(lineKey);
 		if (organizedLine === undefined) continue; // No pieces on line, empty
 
-		const arrowsLineDraft = calcArrowsLineDraft(
-			gamefile,
-			boundingBoxInt!,
-			boundingBoxFloat!,
-			slide,
-			slideKey,
-			organizedLine,
-		);
+		const arrowsLineDraft = calcArrowsLineDraft(gamefile, slide, slideKey, organizedLine);
 		if (arrowsLineDraft === undefined) continue; // Only intersects the corner of our screen, not visible.
 
 		// Remove Unnecessary arrows...
-
-		const slideExceptions = getSlideExceptions();
 		if (!slideExceptions.includes(slideKey)) {
 			removeTypesThatCantSlideOntoScreenFromLineDraft(arrowsLineDraft);
 			if (arrowsLineDraft.negDotProd.length === 0 && arrowsLineDraft.posDotProd.length === 0)
 				continue; // No more pieces on this line
 		}
 
-		// Calculate more detailed information, enough to render...
-
-		const worldHalfWidth = getArrowIndicatorHalfWidth();
-
-		const pointerWorlds = mouse.getAllPointerWorlds();
-
-		const vector = slide;
-		const negVector = vectors.negateVector(slide);
-
-		const posDotProd: Arrow[] = [];
-		const negDotProd: Arrow[] = [];
-
-		arrowsLineDraft.posDotProd.forEach((arrowDraft, index) => {
-			const arrow = processPiece(
-				arrowDraft.piece,
-				vector,
-				arrowsLineDraft.intersections[0],
-				index,
-				worldHalfWidth,
-				pointerWorlds,
-				false,
-			);
-			posDotProd.push(arrow);
-		});
-
-		arrowsLineDraft.negDotProd.forEach((arrowDraft, index) => {
-			const arrow = processPiece(
-				arrowDraft.piece,
-				negVector,
-				arrowsLineDraft.intersections[1],
-				index,
-				worldHalfWidth,
-				pointerWorlds,
-				false,
-			);
-			negDotProd.push(arrow);
-		});
-
 		slideArrows[slideKey] = slideArrows[slideKey] ?? {}; // Make sure this exists first.
-		slideArrows[slideKey][lineKey] = { posDotProd, negDotProd }; // Set the new arrow line
+		// prettier-ignore
+		slideArrows[slideKey][lineKey] = convertLineDraftToLine(arrowsLineDraft, slide, slideKey, worldHalfWidth, pointerWorlds, false);
 	}
 }
 
@@ -1402,10 +1362,6 @@ function recalculateLinesThroughCoords(gamefile: FullGame, coords: Coords): void
  * arrows to be updated.
  */
 function render(): void {
-	regenerateModelAndRender();
-}
-
-function regenerateModelAndRender(): void {
 	if (
 		Object.keys(slideArrows).length === 0 &&
 		animatedArrows.length === 0 &&

--- a/src/client/scripts/esm/game/rendering/dragging/dragarrows.ts
+++ b/src/client/scripts/esm/game/rendering/dragging/dragarrows.ts
@@ -59,7 +59,7 @@ interface CandidateArrow {
 	/** The type of the off-screen piece the arrow points to. */
 	pieceType: number;
 	/** The direction vector of the arrow indicator. */
-	vector: Vec2;
+	direction: Vec2;
 	/** The input pointer ID holding the mouse button down. */
 	pointerId: string;
 }
@@ -226,7 +226,7 @@ function detectCandidateArrow(): void {
 		candidate = {
 			pieceCoords,
 			pieceType,
-			vector: hoveredArrow.vector,
+			direction: hoveredArrow.direction,
 			pointerId,
 		};
 		// console.log('Set candidate');
@@ -249,7 +249,7 @@ function findCandidateHoveredArrow(): HoveredArrow | undefined {
 		const hCoords = bdcoords.coordsToBigInt(h.piece.coords);
 		return (
 			coordutil.areCoordsEqual(hCoords, candidate!.pieceCoords) &&
-			coordutil.areCoordsEqual(h.vector, candidate!.vector)
+			coordutil.areCoordsEqual(h.direction, candidate!.direction)
 		);
 	});
 }
@@ -263,7 +263,7 @@ function manageActiveDrag(mouseWorld: DoubleCoords): void {
 	const slideZoneDepth = 2.0 * arrows.getArrowIndicatorHalfWidth() * SLIDE_ZONE_WIDTH;
 	// Always use the 2D screen box for slide zone boundaries, even in perspective mode.
 	const screenBox = camera.getScreenBoundingBox(false);
-	const dir = candidate!.vector;
+	const dir = candidate!.direction;
 
 	const topBarDepth = space.convertPixelsToWorldSpace_Virtual(guinavigation.getHeightOfNavBar());
 	const bottomBarDepth = space.convertPixelsToWorldSpace_Virtual(
@@ -293,7 +293,7 @@ function updateSlideZoneDrag(mouseWorld: DoubleCoords): void {
 
 	const mouseBDCoords: BDCoords = space.convertWorldSpaceToCoords(mouseWorld);
 	const pieceBDCoords: BDCoords = bdcoords.FromCoords(candidate!.pieceCoords);
-	const arrowDir = candidate!.vector;
+	const arrowDir = candidate!.direction;
 	const perpDir = vectors.getPerpendicularVector(arrowDir);
 
 	// Line 1: through mouse in arrow direction.
@@ -428,7 +428,7 @@ function renderSlideZone(): void {
 	const screenBox = camera.getScreenBoundingBox(false);
 	// Slide zone depth in world space units
 	const depth = 2.0 * arrows.getArrowIndicatorHalfWidth() * SLIDE_ZONE_WIDTH;
-	const dir = candidate.vector;
+	const dir = candidate.direction;
 
 	// Build mask geometry — color values are irrelevant, only the geometry is used for stenciling.
 	const maskData: number[] = [];
@@ -494,7 +494,7 @@ function renderSlideMoveHighlights(): void {
 	const moveset = legalmoves.getPieceMoveset(gamefile.boardsim, pieceType);
 
 	// Find the canonical moveset sliding key (x-component is never negative in moveset keys)
-	const normalizedVec: Vec2 = vectors.absVector(candidate.vector);
+	const normalizedVec: Vec2 = vectors.absVector(candidate.direction);
 	const lineKey: Vec2Key = vectors.getKeyFromVec2(normalizedVec);
 
 	// If the slide direction is orthogonal, skip. The entire orthogonal lines are already outlined in draganimation.ts

--- a/src/client/scripts/esm/game/rendering/dragging/dragarrows.ts
+++ b/src/client/scripts/esm/game/rendering/dragging/dragarrows.ts
@@ -207,6 +207,7 @@ function detectCandidateArrow(): void {
 	if (hoveredArrowsList.length === 0) return;
 
 	// Claim the mouse down for any arrow hover to prevent board drag.
+	// Mouse down for move hint arrow indicators must be claimed separately.
 	mouse.claimMouseDown(Mouse.LEFT);
 
 	// Early exit on dragging disabled now, since the mouse down has been claimed.

--- a/src/client/scripts/esm/game/rendering/highlights/annotations/drawsquares.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/annotations/drawsquares.ts
@@ -25,16 +25,10 @@ import { Mouse } from '../../../input.js';
 import preferences from '../../../../components/header/preferences.js';
 import squarerendering from '../squarerendering.js';
 
-// Variables -----------------------------------------------------------------
+// Constants -----------------------------------------------------------------
 
 /** The color of preset squares for the variant. */
 const PRESET_SQUARE_COLOR: Color = [1, 0.2, 0, 0.24]; // Default: 0.19   Transparent orange (makes preset squares less noticeable/distracting)
-
-/**
- * The preset square overrides if provided from the ICN.
- * These override the variant's preset squares.
- */
-let preset_squares: Square[] | undefined;
 
 /**
  * To make single Square highlight more visible than rays (which
@@ -43,11 +37,19 @@ let preset_squares: Square[] | undefined;
 const OPACITY_OFFSET = 0.08;
 
 /** ADDITONAL (not overriding) opacity when hovering over highlights. */
-const hover_opacity = 0.5;
+const HOVER_OPACITY = 0.5;
+
+// Variables -----------------------------------------------------------------
+
+/**
+ * The preset square overrides if provided from the ICN.
+ * These override the variant's preset squares.
+ */
+let preset_squares: Square[] | undefined;
 
 // Updating -----------------------------------------------------------------
 
-/** Returns a list of all drawn-square highlights being hovered over by any pointer. */
+/** Returns a list of all square highlights being hovered over by any pointer. */
 function getAllSquaresHovered(highlights: Square[]): Coords[] {
 	const allHovered: Square[] = [];
 
@@ -195,7 +197,7 @@ function render(highlights: Square[]): void {
 	const allHovered = getAllSquaresHovered(highlights);
 	if (allHovered.length > 0) {
 		const hoverColor = preferences.getAnnoteSquareColor();
-		hoverColor[3] = hover_opacity;
+		hoverColor[3] = HOVER_OPACITY;
 		squarerendering.genModel(allHovered, hoverColor).render(undefined, undefined, { u_size });
 	}
 }
@@ -204,7 +206,9 @@ function render(highlights: Square[]): void {
 
 export default {
 	PRESET_SQUARE_COLOR,
+	HOVER_OPACITY,
 	update,
+	getAllSquaresHovered,
 	getSquaresBelowWorld,
 	setPresetOverrides,
 	getPresetOverrides,

--- a/src/client/scripts/esm/game/rendering/highlights/highlights.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/highlights.ts
@@ -22,6 +22,7 @@ import checkhighlight from './checkhighlight.js';
 import squarerendering from './squarerendering.js';
 import legalmovehighlights from './legalmovehighlights.js';
 import specialrighthighlights from './specialrighthighlights.js';
+import selectedpieceindividualmovehints from './selectedpieceindividualmovehints.js';
 
 /**
  * Renders all highlights, including:
@@ -43,6 +44,7 @@ function render(boardsim: Board): void {
 	premoves.render(); // Premove highlights
 	// Needs to render EVEN if zoomed out (different mode)
 	annotations.render_belowPieces(); // The square highlights added by the user
+	selectedpieceindividualmovehints.render(); // Individual legal move hints when in check
 	enginegame.render(); // Engine games can render a debug of engine generated moves
 }
 

--- a/src/client/scripts/esm/game/rendering/highlights/highlights.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/highlights.ts
@@ -15,6 +15,7 @@ import moveutil from '../../../../../../shared/chess/util/moveutil.js';
 
 import boardpos from '../boardpos.js';
 import premoves from '../../chess/premoves.js';
+import movehints from './movehints.js';
 import enginegame from '../../misc/enginegame.js';
 import annotations from './annotations/annotations.js';
 import preferences from '../../../components/header/preferences.js';
@@ -22,7 +23,6 @@ import checkhighlight from './checkhighlight.js';
 import squarerendering from './squarerendering.js';
 import legalmovehighlights from './legalmovehighlights.js';
 import specialrighthighlights from './specialrighthighlights.js';
-import selectedpieceindividualmovehints from './selectedpieceindividualmovehints.js';
 
 /**
  * Renders all highlights, including:
@@ -44,7 +44,7 @@ function render(boardsim: Board): void {
 	premoves.render(); // Premove highlights
 	// Needs to render EVEN if zoomed out (different mode)
 	annotations.render_belowPieces(); // The square highlights added by the user
-	selectedpieceindividualmovehints.render(); // Individual legal move hints when in check
+	movehints.render(); // Individual legal move hints when in check
 	enginegame.render(); // Engine games can render a debug of engine generated moves
 }
 

--- a/src/client/scripts/esm/game/rendering/highlights/movehints.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/movehints.ts
@@ -1,4 +1,4 @@
-// src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
+// src/client/scripts/esm/game/rendering/highlights/movehints.ts
 
 /**
  * This script renders individual legal move hints when the position is in check

--- a/src/client/scripts/esm/game/rendering/highlights/selectedpiecehighlightline.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/selectedpiecehighlightline.ts
@@ -1,7 +1,7 @@
 // src/client/scripts/esm/game/rendering/highlights/selectedpiecehighlightline.ts
 
 /**
- * [ZOOMED OUT] This script calculates and renders the highlight lines
+ * [Zoomed out] This script calculates and renders the highlight lines
  * of the currently selected piece's legal moves.
  */
 

--- a/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
@@ -20,6 +20,7 @@ import guipause from '../../gui/guipause.js';
 import snapping from './snapping.js';
 import selection from '../../chess/selection.js';
 import gameloader from '../../chess/gameloader.js';
+import drawsquares from './annotations/drawsquares.js';
 import preferences from '../../../components/header/preferences.js';
 import { GameBus } from '../../GameBus.js';
 import squarerendering from './squarerendering.js';
@@ -86,13 +87,20 @@ function getSquares(): Coords[] {
 function render(): void {
 	if (individualMoves.length === 0 || !boardpos.areZoomedOut() || guipause.areWePaused()) return;
 
-	const color_options = {
+	const color: Color = preferences.getLegalMoveHighlightColor({
 		isOpponentPiece: false,
 		isPremove: false,
-	};
-	const color: Color = preferences.getLegalMoveHighlightColor(color_options);
+	});
 	const u_size = snapping.getEntityWidthWorld();
 	squarerendering.genModel(individualMoves, color).render(undefined, undefined, { u_size });
+
+	// Render hovered move hints at higher opacity
+	const allHovered = drawsquares.getAllSquaresHovered(individualMoves);
+	if (allHovered.length > 0) {
+		const hoverColor: Color = [...color];
+		hoverColor[3] = drawsquares.HOVER_OPACITY;
+		squarerendering.genModel(allHovered, hoverColor).render(undefined, undefined, { u_size });
+	}
 }
 
 // Exports -------------------------------------------------------------------------

--- a/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
@@ -1,0 +1,104 @@
+// src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
+
+/**
+ * This script renders individual legal move hints when the position is in check
+ * and our own piece is selected:
+ *
+ * [Zoomed out] Green entity squares at each individual legal move location.
+ * [Zoomed in]  Arrow indicators (via arrows.ts) for off-screen individual legal moves.
+ */
+
+import type { Color } from '../../../../../../shared/util/math/math.js';
+import type { Coords } from '../../../../../../shared/chess/util/coordutil.js';
+import type { LegalMoves } from '../../../../../../shared/chess/logic/legalmoves.js';
+
+import gamefileutility from '../../../../../../shared/chess/util/gamefileutility.js';
+
+import boardpos from '../boardpos.js';
+import gameslot from '../../chess/gameslot.js';
+import guipause from '../../gui/guipause.js';
+import snapping from './snapping.js';
+import selection from '../../chess/selection.js';
+import gameloader from '../../chess/gameloader.js';
+import preferences from '../../../components/header/preferences.js';
+import { GameBus } from '../../GameBus.js';
+import squarerendering from './squarerendering.js';
+
+// Variables -----------------------------------------------------------------------
+
+/** The coords of the selected piece that owns the individual moves, or undefined. */
+let selectedPieceCoords: Coords | undefined;
+/** The individual legal moves to highlight, if conditions are met. Empty otherwise. */
+let individualMoves: Coords[] = [];
+
+// Event Listeners ------------------------------------------------------------------
+
+GameBus.addEventListener('piece-selected', (event) => {
+	const { legalMoves } = event.detail;
+	updateIndividualMoves(legalMoves);
+});
+
+GameBus.addEventListener('piece-unselected', () => {
+	clearIndividualMoves();
+});
+
+// Functions -----------------------------------------------------------------------
+
+/**
+ * Updates the list of individual move hints based on the current selection and game state.
+ * Only sets moves when our own non-premove piece is selected and the position is in check.
+ */
+function updateIndividualMoves(legalMoves: LegalMoves): void {
+	const gamefile = gameslot.getGamefile()!;
+	if (
+		selection.isOpponentPieceSelected() ||
+		!gameloader.isItOurTurn() ||
+		!gamefileutility.isCurrentViewedPositionInCheck(gamefile.boardsim)
+	) {
+		clearIndividualMoves();
+		return;
+	}
+
+	individualMoves = legalMoves.individual;
+	selectedPieceCoords = selection.getPieceSelected()!.coords;
+}
+
+function clearIndividualMoves(): void {
+	individualMoves = [];
+	selectedPieceCoords = undefined;
+}
+
+// Export for snapping.ts ---------------------------------------------------------
+
+/** Returns the coords of the selected piece that owns the individual move hints, or undefined. */
+function getPieceCoords(): Coords | undefined {
+	return selectedPieceCoords;
+}
+
+/** Returns the current list of individual legal move hint squares. */
+function getSquares(): Coords[] {
+	return individualMoves;
+}
+
+// Rendering -----------------------------------------------------------------------
+
+/** [Zoomed out] Renders the individual legal move hint squares as green entity squares. */
+function render(): void {
+	if (individualMoves.length === 0 || !boardpos.areZoomedOut() || guipause.areWePaused()) return;
+
+	const color_options = {
+		isOpponentPiece: false,
+		isPremove: false,
+	};
+	const color: Color = preferences.getLegalMoveHighlightColor(color_options);
+	const u_size = snapping.getEntityWidthWorld();
+	squarerendering.genModel(individualMoves, color).render(undefined, undefined, { u_size });
+}
+
+// Exports -------------------------------------------------------------------------
+
+export default {
+	getPieceCoords,
+	getSquares,
+	render,
+};

--- a/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/selectedpieceindividualmovehints.ts
@@ -12,6 +12,9 @@ import type { Color } from '../../../../../../shared/util/math/math.js';
 import type { Coords } from '../../../../../../shared/chess/util/coordutil.js';
 import type { LegalMoves } from '../../../../../../shared/chess/logic/legalmoves.js';
 
+import vectors from '../../../../../../shared/util/math/vectors.js';
+import coordutil from '../../../../../../shared/chess/util/coordutil.js';
+import legalmoves from '../../../../../../shared/chess/logic/legalmoves.js';
 import gamefileutility from '../../../../../../shared/chess/util/gamefileutility.js';
 
 import boardpos from '../boardpos.js';
@@ -60,8 +63,15 @@ function updateIndividualMoves(legalMoves: LegalMoves): void {
 		return;
 	}
 
-	individualMoves = legalMoves.individual;
-	selectedPieceCoords = selection.getPieceSelected()!.coords;
+	const piece = selection.getPieceSelected()!;
+	selectedPieceCoords = piece.coords;
+	const moveset = legalmoves.getPieceMoveset(gamefile.boardsim, piece.type);
+	individualMoves = legalMoves.individual.filter((hintSquare) => {
+		const diff = coordutil.subtractCoords(hintSquare, selectedPieceCoords!);
+		const dir = vectors.absVector(vectors.normalizeVector(diff));
+		const vec2Key = vectors.getKeyFromVec2(dir);
+		return !!(moveset.sliding && moveset.sliding[vec2Key]);
+	});
 }
 
 function clearIndividualMoves(): void {

--- a/src/client/scripts/esm/game/rendering/highlights/snapping.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/snapping.ts
@@ -39,6 +39,7 @@ import annotations from './annotations/annotations.js';
 import spritesheet from '../spritesheet.js';
 import preferences from '../../../components/header/preferences.js';
 import selectedpiecehighlightline from './selectedpiecehighlightline.js';
+import selectedpieceindividualmovehints from './selectedpieceindividualmovehints.js';
 import { Renderable, createRenderable } from '../../../webgl/Renderable.js';
 
 // Variables --------------------------------------------------------------
@@ -91,11 +92,11 @@ function getEntityWidthWorld(): number {
 
 function getAllEntitiesWorldHovers(world: DoubleCoords): Coords[] {
 	const imagesHovered = miniimage.getImagesBelowWorld(world, false).images;
-	const highlightsHovered = drawsquares.getSquaresBelowWorld(
-		annotations.getSquares(),
-		world,
-		false,
-	).squares;
+	const allSquares: Coords[] = [
+		...annotations.getSquares(),
+		...selectedpieceindividualmovehints.getSquares(),
+	];
+	const highlightsHovered = drawsquares.getSquaresBelowWorld(allSquares, world, false).squares;
 	return [...imagesHovered, ...highlightsHovered];
 }
 
@@ -116,11 +117,11 @@ function getClosestEntityToWorld(world: DoubleCoords): ClosestEntity | undefined
 	let closestEntity: ClosestEntity | undefined = undefined;
 
 	const imagesHovered = miniimage.getImagesBelowWorld(world, true);
-	const highlightsHovered = drawsquares.getSquaresBelowWorld(
-		annotations.getSquares(),
-		world,
-		true,
-	);
+	const allSquares: Coords[] = [
+		...annotations.getSquares(),
+		...selectedpieceindividualmovehints.getSquares(),
+	];
+	const highlightsHovered = drawsquares.getSquaresBelowWorld(allSquares, world, true);
 
 	// Pieces
 	for (let i = 0; i < imagesHovered.images.length; i++) {
@@ -130,7 +131,7 @@ function getClosestEntityToWorld(world: DoubleCoords): ClosestEntity | undefined
 			closestEntity = { coords, dist, type: 'miniimage', index: i };
 	}
 
-	// Square Highlights
+	// Square Highlights and Individual legal move hints
 	for (let i = 0; i < highlightsHovered.squares.length; i++) {
 		const coords = highlightsHovered.squares[i]!;
 		const dist = highlightsHovered.dists![i]!;

--- a/src/client/scripts/esm/game/rendering/highlights/snapping.ts
+++ b/src/client/scripts/esm/game/rendering/highlights/snapping.ts
@@ -31,6 +31,7 @@ import drawrays from './annotations/drawrays.js';
 import boardpos from '../boardpos.js';
 import miniimage from '../miniimage.js';
 import { Mouse } from '../../input.js';
+import movehints from './movehints.js';
 import Transition from '../transitions/Transition.js';
 import primitives from '../primitives.js';
 import perspective from '../perspective.js';
@@ -39,7 +40,6 @@ import annotations from './annotations/annotations.js';
 import spritesheet from '../spritesheet.js';
 import preferences from '../../../components/header/preferences.js';
 import selectedpiecehighlightline from './selectedpiecehighlightline.js';
-import selectedpieceindividualmovehints from './selectedpieceindividualmovehints.js';
 import { Renderable, createRenderable } from '../../../webgl/Renderable.js';
 
 // Variables --------------------------------------------------------------
@@ -92,10 +92,7 @@ function getEntityWidthWorld(): number {
 
 function getAllEntitiesWorldHovers(world: DoubleCoords): Coords[] {
 	const imagesHovered = miniimage.getImagesBelowWorld(world, false).images;
-	const allSquares: Coords[] = [
-		...annotations.getSquares(),
-		...selectedpieceindividualmovehints.getSquares(),
-	];
+	const allSquares: Coords[] = [...annotations.getSquares(), ...movehints.getSquares()];
 	const highlightsHovered = drawsquares.getSquaresBelowWorld(allSquares, world, false).squares;
 	return [...imagesHovered, ...highlightsHovered];
 }
@@ -117,10 +114,7 @@ function getClosestEntityToWorld(world: DoubleCoords): ClosestEntity | undefined
 	let closestEntity: ClosestEntity | undefined = undefined;
 
 	const imagesHovered = miniimage.getImagesBelowWorld(world, true);
-	const allSquares: Coords[] = [
-		...annotations.getSquares(),
-		...selectedpieceindividualmovehints.getSquares(),
-	];
+	const allSquares: Coords[] = [...annotations.getSquares(), ...movehints.getSquares()];
 	const highlightsHovered = drawsquares.getSquaresBelowWorld(allSquares, world, true);
 
 	// Pieces

--- a/src/shared/chess/logic/movesets.ts
+++ b/src/shared/chess/logic/movesets.ts
@@ -39,7 +39,7 @@ interface RawPieceMoveset {
 	 *
 	 * The *key* is the step amount of each skip, and the *value* is the skip limit in the -x and +x directions (-y and +y if it's vertical).
 	 *
-	 * THE X-KEY SHOULD NEVER BE NEGATIVE!!!
+	 * THE X-KEY SHOULD NEVER BE NEGATIVE!!! And if it's 0, then Y should be positive.
 	 */
 	sliding?: SlidingMoves;
 	/**

--- a/src/shared/util/math/vectors.ts
+++ b/src/shared/util/math/vectors.ts
@@ -288,19 +288,19 @@ function absVector(vec2: Vec2): Vec2 {
 	else return vec2;
 }
 
-// /**
-//  * Normalizes a vector to its smallest possible integer components while preserving its direction.
-//  */
-// function normalizeVector(vec2: Vec2): Vec2 {
-// 	// Calculate the GCD of all the components in the vector.
-// 	const gcd = bimath.GCD(vec2[0], vec2[1]);
+/**
+ * Normalizes a vector to its smallest possible integer components while preserving its direction.
+ */
+function normalizeVector(vec2: Vec2): Vec2 {
+	// Calculate the GCD of all the components in the vector.
+	const gcd = bimath.GCD(vec2[0], vec2[1]);
 
-// 	// If the GCD is 0, it means all elements were 0
-// 	if (gcd === 0n) return [0n, 0n];
+	// If the GCD is 0, it means all elements were 0
+	if (gcd === 0n) return [0n, 0n];
 
-// 	// Divide each component by the GCD to get the smallest integer representation.
-// 	return [vec2[0] / gcd, vec2[1] / gcd];
-// }
+	// Divide each component by the GCD to get the smallest integer representation.
+	return [vec2[0] / gcd, vec2[1] / gcd];
+}
 
 /**
  * Normalizes a floating point arbitrarily large vector into a range
@@ -457,7 +457,7 @@ export default {
 	negateBDVector,
 	negateDoubleVector,
 	absVector,
-	// normalizeVector,
+	normalizeVector,
 	normalizeVectorBD,
 	getPerpendicularVector,
 	getPerpendicularLine,


### PR DESCRIPTION
When you are in check, and you select one of your sliding pieces, off screen legal moves are hinted with arrow indicators pointing to them. And, if you are zoomed out, clickable green square highlights are also visible where you can move.

fixes #796 