### PR TITLE
Patch IP Spoofing Vulnerability

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,8 +12,10 @@ import { configureMiddleware } from './middleware/middleware.js';
 
 const app = express();
 
-// This ensures that req.ip will give us the real user's IP instead of the Cloudflare proxy's IP.
-app.set('trust proxy', 1); // '1' means trust the first proxy hop (Cloudflare)
+// Trust 1 proxy hop (Cloudflare) so req.ip reflects the real client.
+// This number must match the actual proxy count, AND all traffic
+// must reach the origin only through Cloudflare. See utility/IP.ts.
+app.set('trust proxy', 1);
 app.disable('x-powered-by'); // This removes the 'x-powered-by' header from all responses.
 
 // Set EJS as the view engine

--- a/src/server/controllers/createAccountController.ts
+++ b/src/server/controllers/createAccountController.ts
@@ -19,6 +19,7 @@ import { RegExpMatcher, englishDataset, englishRecommendedTransformers } from 'o
 import validators from '../../shared/util/validators.js';
 
 import { handleLogin } from './loginController.js';
+import { getClientIP } from '../utility/IP.js';
 import { isBlacklisted } from '../database/blacklistManager.js';
 import { getTranslationForReq } from '../utility/translate.js';
 import { sendEmailConfirmation } from './emailController.js';
@@ -66,7 +67,7 @@ async function createNewMember(req: Request, res: Response): Promise<void> {
 	if (recoveryEmail.length > 0) {
 		const username = typeof req.body.username === 'string' ? req.body.username : '[empty]';
 		logEventsAndPrint(
-			`Bot signup detected! IP: ${req.ip}, Username: ${username}, User-Agent: ${req.get('User-Agent')}`,
+			`Bot signup detected! IP: ${getClientIP(req)}, Username: ${username}, User-Agent: ${req.get('User-Agent')}`,
 			'newMemberLog.txt',
 		);
 		// Return a normal-looking success so bot doesn't adapt

--- a/src/server/socket/openSocket.ts
+++ b/src/server/socket/openSocket.ts
@@ -13,6 +13,7 @@ import { GAME_VERSION } from '../../shared/game_version.js';
 import { onclose } from './closeSocket.js';
 import socketUtility from './socketUtility.js';
 import { onmessage } from './receiveSocketMessage.js';
+import { getClientIP } from '../utility/IP.js';
 import { executeSafely } from '../utility/errorGuard.js';
 import { sendSocketMessage } from './sendSocketMessage.js';
 import { verifyJWTWebSocket } from '../middleware/verifyJWT.js';
@@ -110,7 +111,7 @@ function closeIfInvalidAndAddMetadata(
 		return;
 	}
 
-	const IP = socketUtility.getIPFromWebsocketUpgradeRequest(req);
+	const IP = getClientIP(req);
 	if (IP === undefined) {
 		logEvents('Unable to identify IP address from websocket connection!', 'hackLog.txt');
 		socket.close(1008, 'Unable to identify client IP address'); // Code 1008 is Policy Violation

--- a/src/server/socket/socketUtility.ts
+++ b/src/server/socket/socketUtility.ts
@@ -123,28 +123,10 @@ function getCookiesFromWebsocket(req: IncomingMessage): { [cookieName: string]: 
 	return cookies;
 }
 
-/**
- * Reads the IP address attached to the incoming websocket connection request,
- * and sets the websocket metadata's `IP` property to that value, then returns that IP.
- * @param req - The request object.
- * @param ws - The websocket object.
- * @returns The IP address of the websocket connection, or `undefined` if not present.
- */
-function getIPFromWebsocketUpgradeRequest(req: IncomingMessage): string | undefined {
-	// Check the headers for the forwarded IP (useful if behind a proxy like Cloudflare)
-	const clientIP = req.headers['x-forwarded-for'] || req.socket.remoteAddress; // ws._socket.remoteAddress
-
-	// If we didn't get a string IP, return undefined
-	if (typeof clientIP !== 'string') return undefined;
-
-	return clientIP;
-}
-
 export default {
 	printSocket,
 	stringifySocketMetadata,
 	getCookiesFromWebsocket,
-	getIPFromWebsocketUpgradeRequest,
 };
 
 export type { CustomWebSocket };

--- a/src/server/utility/IP.ts
+++ b/src/server/utility/IP.ts
@@ -13,6 +13,7 @@ import type { IncomingMessage } from 'http';
  * We read Cloudflare's `cf-connecting-ip` header, which Cloudflare overwrites on
  * every request with a single, trusted client IP (any client-supplied value is
  * stripped). This cannot be forged, unless traffic doesn't come through Cloudflare.
+ *`req.ip` isn't available for raw websocket upgrade requests.
  * @param req - The incoming HTTP request or websocket upgrade request.
  * @returns The client IP as a string, or `undefined` if it can't be determined (e.g. closed socket).
  */

--- a/src/server/utility/IP.ts
+++ b/src/server/utility/IP.ts
@@ -5,26 +5,22 @@
  * requests and websocket connection requests.
  */
 
-import type { Request } from 'express';
+import type { IncomingMessage } from 'http';
 
 /**
- * Reads the IP address attached to the incoming request.
- * It prioritizes the 'x-forwarded-for' header, which is commonly used by
- * reverse proxies and load balancers like Cloudflare to convey the original client IP.
+ * Reads the client IP address attached to the incoming request.
  *
- * @param req - The Express request object.
- * @returns The IP address of the request as a string, or `undefined` if not present.
+ * We read Cloudflare's `cf-connecting-ip` header, which Cloudflare overwrites on
+ * every request with a single, trusted client IP (any client-supplied value is
+ * stripped). This cannot be forged, unless traffic doesn't come through Cloudflare.
+ * @param req - The incoming HTTP request or websocket upgrade request.
+ * @returns The client IP as a string, or `undefined` if it can't be determined (e.g. closed socket).
  */
-export function getClientIP(req: Request): string | undefined {
-	const forwardedFor = req.headers['x-forwarded-for'];
+export function getClientIP(req: IncomingMessage): string | undefined {
+	const cfConnectingIP = req.headers['cf-connecting-ip'];
+	if (typeof cfConnectingIP === 'string') return cfConnectingIP;
 
-	if (typeof forwardedFor === 'string') {
-		// The 'x-forwarded-for' header can be a comma-separated list of IPs.
-		// The first one is the original client IP.
-		return forwardedFor.split(',')[0]!.trim();
-	}
-
-	// Fallback to req.ip, which is derived from req.socket.remoteAddress
-	// (and should match the first entry in 'x-forwarded-for' if behind a proxy)
-	return req.ip;
+	// Fallback for non-Cloudflare contexts (e.g. local development),
+	// where the raw socket peer IS the client.
+	return req.socket.remoteAddress;
 }


### PR DESCRIPTION
The original `getClientIP()` derived the client IP from the leftmost value of the client-supplied `X-Forwarded-For` header, but behind Cloudflare that leftmost entry is fully attacker-controlled (Cloudflare *appends* the real IP on the right rather than overwriting the header), so an unauthenticated user could forge and rotate any IP they wanted—defeating every IP-keyed control at once (rate limiting, IP bans, the login brute-force lockout, session/refresh-token IP tracking, rating-abuse detection, and audit logs), and the WebSocket upgrade path had the same flaw.

This replaces that logic with a read of Cloudflare's `cf-connecting-ip` header, which Cloudflare overwrites on every request with the genuine client IP (stripping any client-supplied value) and which therefore can't be forged, unifies both the HTTP and WebSocket paths through the single hardened `getClientIP()` helper, and falls back to the unspoofable `req.socket.remoteAddress` for non-Cloudflare contexts like local dev, closing the spoofing hole.
