### PR TITLE
fix: remove pause click listener from correct element to stop leak

### DIFF
--- a/src/client/scripts/esm/game/gui/guinavigation.ts
+++ b/src/client/scripts/esm/game/gui/guinavigation.ts
@@ -319,7 +319,7 @@ function closeListeners_Navigation(): void {
 	element_Annotations.removeEventListener('click', callback_Annotations);
 	element_Erase.removeEventListener('click', callback__Collapse);
 	element_Collapse.removeEventListener('click', callback__Collapse);
-	element_Back.removeEventListener('click', callback_Pause);
+	element_pause.removeEventListener('click', callback_Pause);
 
 	element_CoordsX.removeEventListener('change', callback_CoordsXChange);
 	element_CoordsY.removeEventListener('change', callback_CoordsYChange);


### PR DESCRIPTION
Closes #1122 

### Type of Change (new feature, quality of life, bug fix, refactor, tooling, chore, tests, translation, or documentation):

Bug fix

### Scope (what part of the website or game does it apply to):

The in-game navigation bar (`guinavigation.ts`).

### Details of what it does:

`callback_Pause` is added to `element_pause` in `initListeners_Navigation()`,
but `closeListeners_Navigation()` was removing it from `element_Back` instead,
so it was never actually detached.

Because the navigation UI opens and closes repeatedly during a session (every
game start/end, board editor toggle, returning from the pause menu, etc.), a new
pause listener was being added on every cycle and none were ever removed. This
leaked listeners over time and caused a single pause click to fire the handler
multiple times.                                                          
The fix detaches the listener from the correct element — `element_pause` instead
of `element_Back` — which targets the root cause directly. One line changed.

`npm run lint`, `npx tsc --noEmit`, and `npm test` all pass.
