### PR TITLE
fix(navigation): stop the navigation bar from leaking button listeners

### DIFF
--- a/src/client/scripts/esm/game/gui/guinavigation.ts
+++ b/src/client/scripts/esm/game/gui/guinavigation.ts
@@ -77,6 +77,9 @@ const durationToLockRewindAfterMoveForwardingMillis = 750;
 /** Whether the navigation UI is visible (not hidden) */
 let navigationOpen = true;
 
+/** Whether the edit (undo/redo) button listeners were attached instead of the move (rewind/forward) ones. */
+let editButtonsListenersActive = false;
+
 /**
  * Whether the annotations button is enabled.
  * If so, all left click actions are treated as right clicks.
@@ -272,7 +275,8 @@ function initListeners_Navigation(): void {
 	element_CoordsX.addEventListener('change', callback_CoordsXChange);
 	element_CoordsY.addEventListener('change', callback_CoordsYChange);
 
-	if (!guiboardeditor.isOpen()) {
+	editButtonsListenersActive = guiboardeditor.isOpen();
+	if (!editButtonsListenersActive) {
 		element_moveRewind.addEventListener('click', callback_MoveRewind);
 		element_moveRewind.addEventListener('mousedown', callback_MoveRewindMouseDown);
 		element_moveRewind.addEventListener('mouseleave', callback_MoveRewindMouseLeave);
@@ -320,7 +324,8 @@ function closeListeners_Navigation(): void {
 	element_CoordsX.removeEventListener('change', callback_CoordsXChange);
 	element_CoordsY.removeEventListener('change', callback_CoordsYChange);
 
-	if (!guiboardeditor.isOpen()) {
+	// Remove whichever set was added in initListeners_Navigation(), even if the board editor state changed since.
+	if (!editButtonsListenersActive) {
 		element_moveRewind.removeEventListener('click', callback_MoveRewind);
 		element_moveRewind.removeEventListener('mousedown', callback_MoveRewindMouseDown);
 		element_moveRewind.removeEventListener('mouseleave', callback_MoveRewindMouseLeave);


### PR DESCRIPTION
Closes #1126 

### Type of Change (new feature, quality of life, bug fix, refactor, tooling, chore, tests, translation, or documentation):

Bug fix

### Scope (what part of the website or game does it apply to):

The in-game navigation bar (guinavigation.ts).

### Details of what it does (if it makes css style changes, include screenshots of the before & after):

The navigation bar attaches either the move (rewind/forward) or edit (undo/redo) button listeners depending on `guiboardeditor.isOpen()`. Both the init and close routines branched on that same live state to decide which set to touch.

The problem: the editor's open state can change between attaching the listeners and removing them. For example, opening the nav bar in a normal game attaches the move-button listeners; then opening the board editor and toggling the bar closed makes the close routine see `isOpen() === true`, so it removes the undo/redo listeners and leaves the move-button listeners attached. They accumulate on every toggle.

The fix records which set was actually attached and removes that exact set on close, regardless of the editor's current state — targeting the root cause rather than re-guessing the state.

No CSS changes. `npm run type-check` and `npm run lint` pass.