### PR TITLE
Add local engine (vs computer) games, saved like PvP games

### DIFF
--- a/build/client.ts
+++ b/build/client.ts
@@ -52,6 +52,7 @@ export const ESMEntryPoints = [
 
 	// Workers
 	'src/client/scripts/esm/views/analysis/hydrochessanalysis.worker.ts',
+	'src/client/scripts/esm/game/chess/engines/hydrochess.ts', // Gameplay engine worker (engine games on the game page)
 
 	// Other
 	'src/client/scripts/esm/audio/processors/downsampler/DownsamplerProcessor.ts',

--- a/src/client/scripts/esm/game/boardeditor/actions/eactions.ts
+++ b/src/client/scripts/esm/game/boardeditor/actions/eactions.ts
@@ -22,14 +22,15 @@ import type { MetaData, MovePacket } from '../../../../../../shared/types.js';
 import type { EnPassant, GlobalGameState } from '../../../../../../shared/chess/logic/state';
 import type { ActivePosition, StorageType } from '../boardeditor';
 
-import bimath from '../../../../../../shared/util/math/bimath';
 import typeutil from '../../../../../../shared/chess/util/typeutil';
 import movepiece from '../../../../../../shared/chess/logic/movepiece';
 import icnimport from '../../../../../../shared/chess/logic/icn/icnimport.js';
 import metadatautil from '../../../../../../shared/chess/util/metadatautil.js';
+import hydrochess_card from '../../../../../../shared/chess/engines/hydrochess_card';
 import variantpreviewer from '../../../../../../shared/chess/variants/variantpreviewer';
 import { validatePosition } from '../../../../../../shared/chess/variants/positionvalidation';
 import boardutil, { Piece } from '../../../../../../shared/chess/util/boardutil';
+import { engineDictionary } from '../../../../../../shared/chess/engines/engine';
 import coordutil, { Coords, CoordsKey } from '../../../../../../shared/chess/util/coordutil';
 import organizedpieces, {
 	OrganizedPieces,
@@ -56,10 +57,8 @@ import boardeditor from '../boardeditor';
 import edithistory from '../edithistory';
 import validatorama from '../../../util/validatorama';
 import selectiontool from '../tools/selection/selectiontool';
-import hydrochess_card from '../../chess/engines/enginecards/hydrochess_card';
 import guiboardcontrols from '../../gui/guiboardcontrols';
 import clientmetadatautil from '../../chess/clientmetadatautil';
-import { engineDictionary } from '../../chess/engines/engine';
 import gamecompressor, { SimplifiedGameState } from '../../chess/gamecompressor';
 
 // Constants ----------------------------------------------------------------------
@@ -212,38 +211,11 @@ function startEngineGame(engineUIConfig: EngineUIConfig): void {
 
 	// Set world border automatically, if wished
 	if (engineUIConfig.setDefaultWorldBorder) {
-		// Calculate minimum bounding box of all pieces
-		const bb = boardutil.getBoundingBoxOfAllPieces(gameslot.getGamefile()!.pieces)!; // Guaranteed defined since above we check if there's > 0 pieces
-
-		/*
-		 * Priority:
-		 * 1. Default distance
-		 * 2. Capped at engine's cap
-		 */
-
-		const worldBorderProperty = engineDictionary[currentEngine].worldBorder;
-		const cap = hydrochess_card.BORDER_CAP;
-
-		// How far can we extend in each direction before hitting ±limit?
-		const availableLeft = bb.left + cap;
-		const availableRight = cap - bb.right;
-		const availableBottom = bb.bottom + cap;
-		const availableTop = cap - bb.top;
-
-		// Calculate separate limiting distances for horizontal and vertical axes
-		const availableHorz = bimath.min(availableLeft, availableRight);
-		const availableVert = bimath.min(availableBottom, availableTop);
-
-		// Use the minimum between the default and the capped
-		const distHorz = bimath.min(worldBorderProperty, availableHorz);
-		const distVert = bimath.min(worldBorderProperty, availableVert);
-
-		variantOptions.gameRules.worldBorder = {
-			left: bb.left - distHorz,
-			right: bb.right + distHorz,
-			bottom: bb.bottom - distVert,
-			top: bb.top + distVert,
-		};
+		delete variantOptions.gameRules.worldBorder; // The user opted into the default — override any existing border.
+		hydrochess_card.setDefaultWorldBorder(
+			variantOptions,
+			engineDictionary[currentEngine].worldBorder,
+		);
 	}
 
 	// Does the engine support the position and settings?

--- a/src/client/scripts/esm/game/chess/checkmatepractice.ts
+++ b/src/client/scripts/esm/game/chess/checkmatepractice.ts
@@ -15,6 +15,7 @@ import icnconverter from '../../../../../shared/chess/logic/icn/icnconverter.js'
 import gamefileutility from '../../../../../shared/chess/util/gamefileutility.js';
 import validcheckmates from '../../../../../shared/chess/util/validcheckmates.js';
 import variantpreviewer from '../../../../../shared/chess/variants/variantpreviewer.js';
+import { engineDictionary } from '../../../../../shared/chess/engines/engine.js';
 import {
 	players as p,
 	ext as e,
@@ -24,13 +25,13 @@ import {
 import docutil from '../../util/docutil.js';
 import gameslot from './gameslot.js';
 import selection from '../chess/selection.js';
+import enginegame from '../misc/enginegame.js';
 import gameloader from './gameloader.js';
 import gamesession from './gamesession.js';
 import guipractice from '../gui/guipractice.js';
 import LocalStorage from '../../util/LocalStorage.js';
 import movesequence from '../chess/movesequence.js';
 import validatorama from '../../util/validatorama.js';
-import { engineDictionary } from './engines/engine.js';
 import { retryFetch, RetryFetchOptions } from '../../util/fetchRetrier.js';
 
 // Variables ----------------------------------------------------------------------------
@@ -70,6 +71,15 @@ let inCheckmatePractice: boolean = false;
 
 /** Whether the player is allowed to undo a move in the current position. */
 let undoingIsLegal: boolean = false;
+
+// Observe engine-game events (each hook no-ops outside checkmate practice).
+// Registered here rather than called by enginegame, so enginegame never
+// imports this practice-page module onto other pages hosting engine games.
+enginegame.registerHooks({
+	onHumanMove: registerHumanMove,
+	onEngineMove: registerEngineMove,
+	onGameConclude: onEngineGameConclude,
+});
 
 // Functions ----------------------------------------------------------------------------
 
@@ -429,7 +439,4 @@ export default {
 	onGameUnload,
 	updateCompletedCheckmates,
 	eraseCheckmatePracticeProgressFromLocalStorage,
-	onEngineGameConclude,
-	registerHumanMove,
-	registerEngineMove,
 };

--- a/src/client/scripts/esm/game/chess/engines/hydrochess.ts
+++ b/src/client/scripts/esm/game/chess/engines/hydrochess.ts
@@ -4,6 +4,12 @@
  * HydroChess Engine
  * A JavaScript wrapper for the WASM implementation of HydroChess
  *
+ * The engine glue is served UNBUNDLED at a content-versioned `/engine/<hash>/` path (see
+ * build/engine-wasm.ts) and loaded via a runtime dynamic import whose URL arrives in the
+ * init message — the same mechanism as the analysis worker. wasm-bindgen-rayon self-spawns
+ * its Lazy SMP threads by resolving the glue's own `import.meta.url`, which only works when
+ * the glue (and its `snippets/` + .wasm) are real served files; bundling them here breaks it.
+ *
  * @author FirePlank
  */
 
@@ -11,18 +17,21 @@ import icnconverter, {
 	LongFormatIn,
 } from '../../../../../../shared/chess/logic/icn/icnconverter.js';
 
-// @ts-ignore without this, the type check job fails
-import wasmUrl from '../../../../../pkg/hydrochess/pkg/hydrochess_wasm_bg.wasm';
-// @ts-ignore without this, the type check job fails
-import init, * as wasmBindings from '../../../../../pkg/hydrochess/pkg/hydrochess_wasm.js';
-
-const wasm = wasmBindings as typeof wasmBindings;
+/** The engine module's exports (default init + Engine + initThreadPool + …). */
+let wasm: any;
 let wasmInitialized = false;
-let wasmInitPromise: Promise<boolean> | null = null;
 
 interface EngineConfig {
 	engineTimeLimitPerMoveMillis?: number;
 	strengthLevel?: number;
+}
+
+/** The first message from the page: where to load the engine glue, and the Lazy SMP pool size. */
+interface EngineWorkerInitMessage {
+	/** Served engine-glue URL (from the asset manifest). */
+	engineUrl: string;
+	/** Lazy SMP search threads (1 = single-threaded). */
+	threads: number;
 }
 
 interface EngineWorkerMessage {
@@ -43,43 +52,44 @@ interface WasmBestMoveResult {
 	promotion?: string | null;
 }
 
-// Initializes the WASM module.
-// @returns Promise that resolves when the WASM module is initialized
-async function initWasm(): Promise<boolean> {
-	if (!wasmInitPromise) {
+/**
+ * Initializes the WASM module from the served glue, bringing up the
+ * Lazy SMP thread pool when supported, then posts 'readyok'.
+ */
+async function initWasm(msg: EngineWorkerInitMessage): Promise<void> {
+	try {
 		console.debug('[Engine] Initializing HydroChess WASM module');
-		wasmInitPromise = init({ module_or_path: wasmUrl })
-			.then(async () => {
-				console.debug('[Engine] HydroChess WASM module initialized');
-				wasmInitialized = true;
+		// Absolute, computed specifier so the bundler leaves this as a runtime import.
+		const glueUrl = new URL(msg.engineUrl, self.location.origin).href;
+		wasm = await import(glueUrl);
+		await wasm.default(); // Loads the sibling .wasm from the same /engine/<hash>/ dir.
 
-				postMessage('readyok');
-				return true;
-			})
-			.catch((err: unknown) => {
-				console.error('[Engine] Failed to initialize HydroChess WASM module', err);
-				wasmInitialized = false;
-				return false;
-			});
+		// A single-threaded engine build exports no initThreadPool; guard so it
+		// degrades gracefully to a 1-thread search instead of throwing.
+		if (msg.threads > 1 && typeof wasm.initThreadPool === 'function')
+			await wasm.initThreadPool(msg.threads);
+
+		wasmInitialized = true;
+		console.debug('[Engine] HydroChess WASM module initialized');
+		postMessage('readyok');
+	} catch (err: unknown) {
+		console.error('[Engine] Failed to initialize HydroChess WASM module', err);
 	}
-	return wasmInitPromise!;
 }
 
-// Initialize WASM when the module is loaded
-void initWasm();
-
 // Main entry point for the engine
-self.onmessage = async function (e: MessageEvent<EngineWorkerMessage>): Promise<void> {
+self.onmessage = async function (
+	e: MessageEvent<EngineWorkerInitMessage | EngineWorkerMessage>,
+): Promise<void> {
+	// The first message carries the engine-glue URL + thread count.
+	if ('engineUrl' in e.data) return initWasm(e.data);
+
 	const data = e.data;
 
-	// Ensure WASM is initialized before processing commands
 	if (!wasmInitialized) {
-		const initialized = await initWasm();
-		if (!initialized) {
-			console.error('[Engine] WASM module failed to initialize');
-			postMessage({ type: 'move', data: null });
-			return;
-		}
+		console.error('[Engine] Received a request before the WASM module was initialized');
+		postMessage({ type: 'move', data: null });
+		return;
 	}
 
 	try {

--- a/src/client/scripts/esm/game/chess/gameloader.ts
+++ b/src/client/scripts/esm/game/chess/gameloader.ts
@@ -20,13 +20,13 @@ import type { MovePacket, TimeControl } from '../../../../../shared/types.js';
 
 import jsutil from '../../../../../shared/util/jsutil.js';
 import { players as p } from '../../../../../shared/chess/util/typeutil.js';
+import { engineDictionary, ValidEngine } from '../../../../../shared/chess/engines/engine.js';
 
 import gameslot from './gameslot.js';
 import enginegame from '../misc/enginegame.js';
 import guipalette from '../gui/boardeditor/guipalette.js';
 import gamesession from './gamesession.js';
 import boardeditor from '../boardeditor/boardeditor.js';
-import { engineDictionary, ValidEngine } from './engines/engine.js';
 
 // Start Game --------------------------------------------------------------------
 

--- a/src/client/scripts/esm/game/gui/boardeditor/actions/guistartenginegame.ts
+++ b/src/client/scripts/esm/game/gui/boardeditor/actions/guistartenginegame.ts
@@ -20,7 +20,7 @@ import { listener_document } from '../../../chess/gamecore';
 interface EngineUIConfig {
 	youAreColor: Player;
 	timeControl: TimeControl;
-	strengthLevel: 1 | 2 | 3;
+	strengthLevel: number;
 	setDefaultWorldBorder: boolean;
 }
 
@@ -160,8 +160,8 @@ function readEngineUIConfig(): EngineUIConfig {
 		element_timecontrol.classList.add('invalid-input');
 	}
 
-	// Strength level
-	const strengthLevel = element_hard.checked ? 3 : element_medium.checked ? 2 : 1;
+	// Strength level — easy/medium/hard spread across the engine's 1-8 range.
+	const strengthLevel = element_hard.checked ? 8 : element_medium.checked ? 4 : 1;
 
 	// Set default world border
 	const setDefaultWorldBorder = element_yesborder.checked ? true : false;

--- a/src/client/scripts/esm/game/gui/guigameactions.ts
+++ b/src/client/scripts/esm/game/gui/guigameactions.ts
@@ -18,15 +18,18 @@
  * after. Rematch is a placeholder until the server supports it.
  */
 
+import type { GameConclusion } from '../../../../../shared/chess/util/winconutil.js';
 import type { RematchOfferInfo } from '../../../../../shared/types.js';
 
 import uuid from '../../../../../shared/util/uuid.js';
+import typeutil from '../../../../../shared/chess/util/typeutil.js';
 import moveutil from '../../../../../shared/chess/util/moveutil.js';
 import gamefileutility from '../../../../../shared/chess/util/gamefileutility.js';
 
 import gameslot from '../chess/gameslot.js';
 import drawoffers from '../misc/onlinegame/drawoffers.js';
 import { GameBus } from '../GameBus.js';
+import gamesession from '../chess/gamesession.js';
 import { SocketBus } from '../../websocket/SocketBus.js';
 import socketmessages from '../../websocket/socketmessages.js';
 
@@ -200,6 +203,12 @@ function callback_OfferDraw(): void {
 
 /** Resigns the game. Server only accepts if the game is resignable (2+ plies). */
 function callback_Resign(): void {
+	if (gamesession.getGameType() === 'engine') {
+		// Engine games conclude locally; the sync module reports it to the server.
+		const engineColor = typeutil.invertPlayer(gamesession.getRole()!);
+		concludeEngineGameLocally({ victor: engineColor, condition: 'resignation' });
+		return;
+	}
 	socketmessages.send('game', 'resign');
 }
 
@@ -210,7 +219,19 @@ function callback_Resign(): void {
  * but the abort button hadn't yet swapped out for resign.
  */
 function callback_Abort(): void {
+	if (gamesession.getGameType() === 'engine') {
+		concludeEngineGameLocally({ condition: 'aborted' });
+		return;
+	}
 	socketmessages.send('game', 'abort');
+}
+
+/** Concludes the loaded engine game in place (there's no server game to message). */
+function concludeEngineGameLocally(conclusion: GameConclusion): void {
+	const gamefile = gameslot.getGamefile()!;
+	if (gamefile.gameConclusion) return; // Already over (e.g. the engine's move just concluded it).
+	gamefile.gameConclusion = conclusion;
+	gameslot.concludeGame();
 }
 
 /** Navigates to the post-game analysis board. */

--- a/src/client/scripts/esm/game/misc/enginegame.ts
+++ b/src/client/scripts/esm/game/misc/enginegame.ts
@@ -18,7 +18,6 @@ import { GameBus } from '../GameBus.js';
 import gamesession from '../chess/gamesession.js';
 import movesequence from '../chess/movesequence.js';
 import gamecompressor from '../chess/gamecompressor.js';
-import checkmatepractice from '../chess/checkmatepractice.js';
 import enginelegalmovesdebug from './enginelegalmovesdebug.js';
 
 // Types ------------------------------------------------------------------------
@@ -32,6 +31,20 @@ interface EngineConfig {
 	multiPv?: number;
 }
 
+/**
+ * Hooks an interested module (checkmate practice) can register to observe engine-game
+ * events. Registered by the module itself, so this script never imports page-specific
+ * code (e.g. the practice page's GUI) onto other pages hosting engine games.
+ */
+interface EngineGameHooks {
+	/** Called when the human player has made a move. */
+	onHumanMove?: () => void;
+	/** Called when the engine has made a move. */
+	onEngineMove?: () => void;
+	/** Called when the engine game concludes. */
+	onGameConclude?: () => void;
+}
+
 // Variables --------------------------------------------------------------------
 
 /** Whether we are currently in an engine game. */
@@ -40,13 +53,15 @@ let engineColor: Player | undefined;
 let currentEngine: string | undefined; // name of the current engine used
 let engineConfig: EngineConfig | undefined; // json that is sent to the engine, giving it extra config information
 let engineWorker: Worker | undefined;
+/** Observer hooks registered via {@link registerHooks}. */
+let hooks: EngineGameHooks = {};
 
 // Events -----------------------------------------------------------------------
 
 GameBus.addEventListener('user-move-played', () => onMovePlayed());
 GameBus.addEventListener('game-concluded', () => {
 	if (!inEngineGame) return;
-	checkmatepractice.onEngineGameConclude();
+	hooks.onGameConclude?.();
 });
 
 enginelegalmovesdebug.init({
@@ -65,6 +80,13 @@ function initEngineGame(options: {
 	youAreColor: Player;
 	currentEngine: string;
 	engineConfig: EngineConfig;
+	/** Hashed URL of the engine's worker script (from the asset manifest). Falls back to the legacy unhashed path. */
+	workerUrl?: string;
+	/**
+	 * Served engine-glue URL (`manifest['engine']`) for wasm-engine workers that load it at
+	 * runtime (hydrochess). Sent to the worker as an init message, with the thread count.
+	 */
+	engineUrl?: string;
 }): Promise<void> {
 	console.log(`Starting engine game with engine "${options.currentEngine}".`);
 
@@ -81,7 +103,8 @@ function initEngineGame(options: {
 			new Error("Cannot finish loading engine game because web workers aren't supported."),
 		);
 	}
-	engineWorker = new Worker(`../scripts/esm/game/chess/engines/${currentEngine}.js`, {
+	const workerUrl = options.workerUrl ?? `../scripts/esm/game/chess/engines/${currentEngine}.js`;
+	engineWorker = new Worker(workerUrl, {
 		type: 'module',
 	}); // module type allows the web worker to import methods and types from other scripts.
 
@@ -98,6 +121,13 @@ function initEngineGame(options: {
 		engineWorker!.onerror = (e: ErrorEvent): void => {
 			reject(new Error('Worker failed to load: ' + e.message));
 		};
+		// The hydrochess worker initializes its wasm (and Lazy SMP thread pool) on this
+		// message; legacy workers (checkmate practice) self-initialize and never get one.
+		if (options.engineUrl !== undefined)
+			engineWorker!.postMessage({
+				engineUrl: options.engineUrl,
+				threads: getEngineThreadCount(),
+			});
 	}).then((_result: any) => {
 		// After the promise resolves, we know the worker is ready
 		// Overwrite the onmessage listener to listen for move submissions
@@ -119,7 +149,7 @@ function onMovePlayed(): void {
 	const gamefile = gameslot.getGamefile()!;
 	// Make sure it's the engine's turn
 	if (gamefile.whosTurn !== engineColor) return; // Don't do anything if it's our turn (not the engines)
-	checkmatepractice.registerHumanMove(); // inform the checkmatepractice script that the human player has made a move
+	hooks.onHumanMove?.(); // inform the checkmatepractice script that the human player has made a move
 	if (gamefile.gameConclusion) return; // Don't do anything if the game is over
 
 	// Request the engine to perform a best move calculation...
@@ -227,7 +257,7 @@ function makeEngineMove(tokenMove: unknown): void {
 			movesequence.makeMoveKeepingView(gamefile, mesh, moveValidationResults.tagged);
 		}
 
-		checkmatepractice.registerEngineMove(); // inform the checkmatepractice script that the engine has made a move
+		hooks.onEngineMove?.(); // inform the checkmatepractice script that the engine has made a move
 
 		return true; // Good to physically play next premove
 	});
@@ -254,11 +284,27 @@ function requestGeneratedMoves(gamefile: GameFile): void {
 		});
 }
 
+/**
+ * Lazy SMP search threads for the engine: the hardware thread count minus one
+ * (leaving the main thread breathing room), capped at 4. Threading requires
+ * cross-origin isolation (SharedArrayBuffer); without it the engine runs single-threaded.
+ */
+function getEngineThreadCount(): number {
+	if (!globalThis.crossOriginIsolated || typeof SharedArrayBuffer !== 'function') return 1;
+	return Math.min(4, Math.max(1, (navigator.hardwareConcurrency || 2) - 1));
+}
+
+/** Registers observer hooks for engine-game events (see {@link EngineGameHooks}). */
+function registerHooks(newHooks: EngineGameHooks): void {
+	hooks = newHooks;
+}
+
 // Export ---------------------------------------------------------------------------------
 
 export default {
 	initEngineGame,
 	onMovePlayed,
+	registerHooks,
 };
 
 export type { EngineConfig };

--- a/src/client/scripts/esm/views/analysis/analysisenginebounds.ts
+++ b/src/client/scripts/esm/views/analysis/analysisenginebounds.ts
@@ -10,8 +10,7 @@ import type { BoundingBox } from '../../../../../shared/util/math/bounds.js';
 
 import bounds from '../../../../../shared/util/math/bounds.js';
 import boardutil from '../../../../../shared/chess/util/boardutil.js';
-
-import { engineDictionary } from '../../game/chess/engines/engine.js';
+import { engineDictionary } from '../../../../../shared/chess/engines/engine.js';
 
 const ENGINE_WORLD_BORDER_DISTANCE = engineDictionary.hydrochess.worldBorder;
 

--- a/src/client/scripts/esm/views/game/enginegameloader.ts
+++ b/src/client/scripts/esm/views/game/enginegameloader.ts
@@ -1,0 +1,141 @@
+// src/client/scripts/esm/views/game/enginegameloader.ts
+
+/**
+ * The engine-game load path of the game page: fetches the game's resumable state over
+ * HTTP (no socket — the engine runs locally in a wasm worker), loads the gamefile
+ * (fresh, or mid-game with the synced moves + clocks), spins up the engine worker,
+ * and starts the server-record syncing.
+ */
+
+import type { Additional, VariantOptions } from '../../../../../shared/chess/logic/gamefile.js';
+import type { EngineGameState, MovePacket } from '../../../../../shared/types.js';
+
+import uuid from '../../../../../shared/util/uuid.js';
+import clock from '../../../../../shared/chess/logic/clock.js';
+import moveutil from '../../../../../shared/chess/util/moveutil.js';
+import icnimport from '../../../../../shared/chess/logic/icn/icnimport.js';
+import icnconverter from '../../../../../shared/chess/logic/icn/icnconverter.js';
+import { players as p } from '../../../../../shared/chess/util/typeutil.js';
+import { engineDictionary } from '../../../../../shared/chess/engines/engine.js';
+
+import toast from '../../components/toast.js';
+import gameslot from '../../game/chess/gameslot.js';
+import enginegame from '../../game/misc/enginegame.js';
+import gamesession from '../../game/chess/gamesession.js';
+import enginegamesync from './enginegamesync.js';
+import { serverFetch } from '../../util/serverFetch.js';
+
+// Functions ------------------------------------------------------------------------
+
+/** Fetches and loads the engine game named by the page URL. */
+async function loadEngineGame(): Promise<void> {
+	try {
+		const state: EngineGameState = await fetchEngineGameState();
+		loadGameFromState(state);
+	} catch (e: unknown) {
+		console.error('Failed to fetch engine game state:', e);
+		toast.show('Failed to load game. Please refresh.', { error: true });
+	}
+}
+
+/**
+ * Fetches the {@link EngineGameState}.
+ * @throws If the fetch fails, or the server returns
+ * a non-OK response, or the JSON body is malformed.
+ */
+async function fetchEngineGameState(): Promise<EngineGameState> {
+	const response = await serverFetch(
+		`/api/engine-game/${uuid.base10ToBase62(window.gamePageData.id)}`,
+	);
+	if (!response.ok) throw new Error(`Engine game fetch failed (${response.status})`);
+	return await response.json();
+}
+
+/** Loads the game onto the board and sets up the engine-game session. */
+function loadGameFromState(state: EngineGameState): void {
+	// The static setup (variant/time control/creation time) and the
+	// engine info + our color are SSR'd; only the owner reaches here.
+	const { variant, timeControl, timeCreated, engineGame, role } = window.gamePageData;
+
+	gamesession.setSessionGame({ type: 'engine', role: role! });
+
+	const moves: MovePacket[] =
+		state.moves === ''
+			? []
+			: icnimport.movePacketsFromParsed(icnconverter.parseShortFormMoves(state.moves));
+
+	// Custom games rebuild their start position from the recorded ICN.
+	let variantOptions: VariantOptions | undefined;
+	if (variant.kind === 'custom') {
+		const longformOut = icnconverter.ShortToLong_Format(state.position!);
+		variantOptions = icnimport.variantOptionsFromLongFormat(longformOut);
+	}
+
+	const additional: Additional = {
+		moves,
+		variantOptions,
+		// Engine games get a world border so the position stays in the engine's safe range.
+		worldBorderDist: engineDictionary[engineGame!.engine].worldBorder,
+	};
+	if (state.clocks) additional.clockValues = { clocks: state.clocks };
+
+	gameslot
+		.loadGamefile({
+			timeControl,
+			variant: variant.kind === 'preset' ? variant.code : undefined,
+			dateTimestamp: timeCreated,
+			viewWhitePerspective: role !== p.BLACK,
+			additional,
+		})
+		.then(async ({ graphical }) => {
+			// Logical loaded, return graphical promise
+			const gamefile = gameslot.getGamefile()!;
+
+			// A refresh can race the conclusion post — the replayed moves may already
+			// end the game (e.g. checkmate). Conclude locally, then re-post it below.
+			gamesession.concludeGameIfOver();
+
+			if (!gamefile.gameConclusion) {
+				resumeClockTicking(state);
+				/** A promise that resolves when the engine script has been fetched. */
+				await enginegame.initEngineGame({
+					youAreColor: role!,
+					currentEngine: engineGame!.engine,
+					engineConfig: {
+						engineTimeLimitPerMoveMillis:
+							engineDictionary[engineGame!.engine].defaultTimeLimitPerMoveMillis,
+						strengthLevel: engineGame!.strengthLevel,
+					},
+					workerUrl: window.gamePageData.engineWorkerUrl,
+					engineUrl: window.gamePageData.engineUrl,
+				});
+			}
+
+			// Sync starts AFTER the load, so the move replay doesn't fire redundant posts.
+			enginegamesync.init();
+			if (gamefile.gameConclusion) enginegamesync.postConclusion();
+
+			return graphical;
+		})
+		.then(() => gamesession.markLoadingDone()) // Both the engine and graphical promises have resolved
+		.catch((err: Error) => gamesession.onCatchLoadingError(err));
+}
+
+/**
+ * Resumes the clock ticking for whoever's turn it is on a resumed timed game.
+ * The load applied the synced values un-ticking (time didn't run while away).
+ */
+function resumeClockTicking(state: EngineGameState): void {
+	const gamefile = gameslot.getGamefile()!;
+	if (gamefile.untimed || !state.clocks) return;
+	if (!moveutil.isGameResignable(gamefile)) return; // Clocks only tick from ply 2 onward.
+
+	const remaining = gamefile.clocks.currentTime[gamefile.whosTurn]!;
+	clock.edit(gamefile.clocks, {
+		clocks: { ...gamefile.clocks.currentTime },
+		colorTicking: gamefile.whosTurn,
+		timeColorTickingLosesAt: Date.now() + remaining,
+	});
+}
+
+export default { loadEngineGame };

--- a/src/client/scripts/esm/views/game/enginegamesync.ts
+++ b/src/client/scripts/esm/views/game/enginegamesync.ts
@@ -1,0 +1,110 @@
+// src/client/scripts/esm/views/game/enginegamesync.ts
+
+/**
+ * Keeps the server's record of the engine game on this page in sync: posts the full
+ * move list + clocks after every move, and the conclusion when the game ends, so the
+ * game is resumable mid-game and permanently saved once over — like a PvP game.
+ */
+
+import type { GameFile } from '../../../../../shared/chess/logic/gamefile.js';
+import type { PlayerGroup } from '../../../../../shared/chess/util/typeutil.js';
+import type {
+	ConcludeEngineGameBody,
+	EngineGameProgressBody,
+} from '../../../../../shared/types.js';
+
+import uuid from '../../../../../shared/util/uuid.js';
+import icnconverter from '../../../../../shared/chess/logic/icn/icnconverter.js';
+import { players as p } from '../../../../../shared/chess/util/typeutil.js';
+
+import toast from '../../components/toast.js';
+import gameslot from '../../game/chess/gameslot.js';
+import { GameBus } from '../../game/GameBus.js';
+import { serverFetch } from '../../util/serverFetch.js';
+
+// Functions ------------------------------------------------------------------------
+
+/**
+ * Starts syncing the loaded engine game to the server. Call AFTER the logical load,
+ * so the initial move replay doesn't fire redundant progress posts.
+ */
+function init(): void {
+	GameBus.addEventListener('moves-changed', onMovesChanged);
+	GameBus.addEventListener('game-concluded', () => postConclusion());
+}
+
+function onMovesChanged(): void {
+	const gamefile = gameslot.getGamefile();
+	if (!gamefile) return;
+	if (gamefile.gameConclusion) return; // The conclusion post carries the final state.
+	postState('progress', buildProgressBody(gamefile), false);
+}
+
+/** Posts the game's conclusion, permanently saving it server-side. */
+function postConclusion(): void {
+	const gamefile = gameslot.getGamefile()!;
+	const body: ConcludeEngineGameBody = {
+		...buildProgressBody(gamefile),
+		gameConclusion: gamefile.gameConclusion!,
+	};
+	postState('conclude', body, true);
+}
+
+function buildProgressBody(gamefile: GameFile): EngineGameProgressBody {
+	const body: EngineGameProgressBody = { moves: serializeMoves(gamefile) };
+
+	if (!gamefile.untimed) {
+		const clocks: PlayerGroup<number> = {};
+		for (const color of [p.WHITE, p.BLACK]) {
+			const time = gamefile.clocks.currentTime[color];
+			if (time !== undefined) clocks[color] = Math.max(0, Math.round(time));
+		}
+		body.clocks = clocks;
+	}
+
+	return body;
+}
+
+/** Serializes the move list compactly, with clock stamps embedded as `[%clk]` comments. */
+function serializeMoves(gamefile: GameFile): string {
+	if (gamefile.moves.length === 0) return '';
+	return icnconverter.getShortFormMovesFromMoves(gamefile.moves, {
+		compact: true,
+		spaces: false,
+		comments: !gamefile.untimed, // Carries the clock stamps.
+		move_numbers: false,
+		abbrev: true, // Irrelevant here — only applies when compact is false.
+	});
+}
+
+/**
+ * Fire-and-forget state post. `keepalive` lets a small post survive an immediate
+ * navigation away (e.g. clicking Analysis right after the game ends), but caps the
+ * body at 64KB — larger games fall back to a normal request.
+ */
+function postState(
+	endpoint: 'progress' | 'conclude',
+	body: EngineGameProgressBody,
+	surfaceFailure: boolean,
+): void {
+	const json = JSON.stringify(body);
+	serverFetch(`/api/engine-game/${uuid.base10ToBase62(window.gamePageData.id)}/${endpoint}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: json,
+		keepalive: json.length < 60_000,
+	})
+		.then((response) => {
+			if (response.ok) return;
+			console.error(`Engine game ${endpoint} sync failed (${response.status}).`);
+			if (surfaceFailure)
+				toast.show('Failed to save the game to the server.', { error: true });
+		})
+		.catch((error) => {
+			console.error(`Engine game ${endpoint} sync failed:`, error);
+			if (surfaceFailure)
+				toast.show('Failed to save the game to the server.', { error: true });
+		});
+}
+
+export default { init, postConclusion };

--- a/src/client/scripts/esm/views/game/game.ts
+++ b/src/client/scripts/esm/views/game/game.ts
@@ -16,6 +16,7 @@ import LocalStorage from '../../util/LocalStorage.js';
 import frametracker from '../../game/rendering/frametracker.js';
 import frameprofiler from '../../game/misc/frameprofiler.js';
 import deadgameloader from '../../game/misc/onlinegame/deadgameloader.js';
+import enginegameloader from './enginegameloader.js';
 
 import '../../game/gui/guisidebar.js';
 import '../../game/misc/onlinegame/onlinegamerouter.js';
@@ -31,7 +32,10 @@ function start(): void {
 
 	initListeners();
 
-	if (window.gamePageData.isLive) {
+	if (window.gamePageData.engineGame) {
+		// Live engine game: fetch its state over HTTP and run the engine locally — no socket opened.
+		void enginegameloader.loadEngineGame();
+	} else if (window.gamePageData.isLive) {
 		onlinegame.subscribeToGame(); // Naturally requests the full game state which bootstraps the game
 	} else {
 		// Dead (memory-evicted) game: fetch its state over HTTP and render it — no socket opened.

--- a/src/client/scripts/esm/views/index/gameSetupModal.ts
+++ b/src/client/scripts/esm/views/index/gameSetupModal.ts
@@ -6,15 +6,20 @@
 
 import type { Player } from '../../../../../shared/chess/util/typeutil.js';
 import type { ModalMode } from '../../components/gameSetupModalHandoff.js';
-import type { GameMode, TimeControl } from '../../../../../shared/types.js';
+import type { CreateEngineGameBody, GameMode, TimeControl } from '../../../../../shared/types.js';
 
+import uuid from '../../../../../shared/util/uuid.js';
 import { players } from '../../../../../shared/chess/util/typeutil.js';
+import hydrochess_card from '../../../../../shared/chess/engines/hydrochess_card.js';
 import { isRatedAllowed } from '../../../../../shared/chess/variants/servervalidation.js';
+import { engineDictionary, ValidEngine } from '../../../../../shared/chess/engines/engine.js';
 
 import lobby from './lobby.js';
 import toast from '../../components/toast.js';
+import gamesound from '../../game/misc/gamesound.js';
 import timeControls from './timeControls.js';
 import variantSelector from './variantSelector.js';
+import { serverFetch } from '../../util/serverFetch.js';
 import modifierSelector from './modifierSelector.js';
 import gameSetupModalHandoff from '../../components/gameSetupModalHandoff.js';
 
@@ -32,11 +37,14 @@ const SUBMIT_LABELS: Record<ModalMode, string> = {
 	computer: t.index.lobby_buttons.play_computer,
 };
 
+/** The engine computer games are played against. */
+const COMPUTER_GAME_ENGINE: ValidEngine = 'hydrochess';
+
 // Elements ----------------------------------------------
 
 const element_modalOverlay = document.getElementById('modal-overlay')!;
 const element_modalClose = document.getElementById('modal-close')!;
-const element_modalSubmit = document.getElementById('modal-submit')!;
+const element_modalSubmit = document.getElementById('modal-submit') as HTMLButtonElement;
 const element_btnCreateOnline = document.getElementById('btn-create-game')!;
 const element_btnChallengeFriend = document.getElementById('btn-challenge-friend')!;
 const element_btnPlayComputer = document.getElementById('btn-play-ai')!;
@@ -111,8 +119,7 @@ function initModal(): void {
 		if (currentMode === 'online') handleOnlineSeek();
 		else if (currentMode === 'friend')
 			toast.show('Friend challenge flow not implemented yet', { error: true });
-		else if (currentMode === 'computer')
-			toast.show('Computer game flow not implemented yet', { error: true });
+		else if (currentMode === 'computer') void handleComputerGame();
 		else console.error('Invalid modal mode:', currentMode);
 	});
 
@@ -168,6 +175,88 @@ function handleOnlineSeek(): void {
 	close();
 }
 
+/**
+ * Reads the computer game form state, asks the server to create the engine game,
+ * and hard-navigates to its game page — where the engine runs locally in wasm.
+ */
+async function handleComputerGame(): Promise<void> {
+	const variant = variantSelector.getInviteVariant();
+	if (variant === null) return; // Invalid selection (e.g. unparsable icn or illegal position)
+
+	if (!isVariantSupportedByEngine()) return; // Error toast already shown.
+
+	const time: TimeControl = timeControls.getTimeControl();
+	// The engine takes whichever color the player doesn't.
+	const color = (getSelectedColor() ?? (Math.random() < 0.5 ? players.WHITE : players.BLACK)) as CreateEngineGameBody['color']; // prettier-ignore
+	const strengthLevel = getSelectedEngineStrength();
+
+	const body: CreateEngineGameBody = {
+		variant,
+		timeControl: time,
+		color,
+		engine: COMPUTER_GAME_ENGINE,
+		strengthLevel,
+	};
+
+	element_modalSubmit.disabled = true; // No double-submits while the request is in flight.
+	try {
+		const response = await serverFetch('/api/engine-game', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		const data: { id?: number; message?: string } = await response.json();
+		if (!response.ok || data.id === undefined)
+			throw new Error(data.message ?? `Failed to create the game (${response.status}).`);
+
+		// Plays the notify sound and awaits it so the hard-navigate doesn't cut it off.
+		const sound = await gamesound.playNotify(false);
+		if (sound) await sound.whenEnded;
+		window.location.assign(`/game/${uuid.base10ToBase62(data.id)}`);
+	} catch (e) {
+		toast.show(e instanceof Error ? e.message : 'Failed to create the game.', { error: true });
+		element_modalSubmit.disabled = false;
+	}
+}
+
+/**
+ * Whether the engine supports the selected variant/position,
+ * showing an error toast when it doesn't.
+ */
+function isVariantSupportedByEngine(): boolean {
+	const customOptions = variantSelector.getSelectedVariantOptions();
+
+	if (customOptions === null) {
+		// Preset selection: the engine plays a fixed set of variants.
+		const variant = variantSelector.getInviteVariant();
+		if (variant?.kind === 'preset' && !hydrochess_card.SUPPORTED_VARIANTS.has(variant.code)) {
+			toast.show("The engine doesn't support this variant yet.", { error: true });
+			return false;
+		}
+		return true;
+	}
+
+	// Custom position: check it the same way the game will load it — with the
+	// engine's default world border applied when the position lacks one.
+	const checkedOptions = { ...customOptions, gameRules: { ...customOptions.gameRules } };
+	hydrochess_card.setDefaultWorldBorder(
+		checkedOptions,
+		engineDictionary[COMPUTER_GAME_ENGINE].worldBorder,
+	);
+	const result = hydrochess_card.isPositionSupported(checkedOptions);
+	if (!result.supported) {
+		toast.show(`The engine doesn't support this position. ${result.reason}`, { error: true });
+		return false;
+	}
+	return true;
+}
+
+/** The selected engine strength level (the modal's Strength row mirrors the engine's 1-8 range). */
+function getSelectedEngineStrength(): number {
+	const levelBtn = document.querySelector<HTMLElement>('[data-level].active')!;
+	return Number(levelBtn.getAttribute('data-level')!);
+}
+
 /** Opens the modal and adjusts mode-specific rows and submit labeling. */
 function openModal(mode: ModalMode): void {
 	lobby.exitIdle();
@@ -177,6 +266,8 @@ function openModal(mode: ModalMode): void {
 
 	element_rowGameMode.classList.toggle('hidden', mode === 'computer');
 	element_rowStrength.classList.toggle('hidden', mode !== 'computer');
+	// Computer games can only be preset variants the engine supports.
+	variantSelector.setEngineOnlyVariants(mode === 'computer');
 
 	element_modalOverlay.classList.remove('hidden');
 

--- a/src/client/scripts/esm/views/index/variantSelector.ts
+++ b/src/client/scripts/esm/views/index/variantSelector.ts
@@ -19,6 +19,7 @@ import { attributesModule, classModule, eventListenersModule, h, init } from 'sn
 
 import icnimport from '../../../../../shared/chess/logic/icn/icnimport.js';
 import icnconverter from '../../../../../shared/chess/logic/icn/icnconverter.js';
+import hydrochess_card from '../../../../../shared/chess/engines/hydrochess_card.js';
 import variantregistry from '../../../../../shared/chess/variants/variantregistry.js';
 import { validatePosition } from '../../../../../shared/chess/variants/positionvalidation.js';
 
@@ -187,6 +188,36 @@ function closeVariantDropdown(): void {
 function openVariantList(group: VariantGroup): void {
 	element_variantGroupDropdown.classList.remove('open');
 	element_variantListPanelByGroup.get(group)!.classList.add('open');
+}
+
+/**
+ * Restricts the selector to engine-supported variants (the computer-game flow), or lifts
+ * the restriction. Hides unsupported preset variants — and any group left empty — rather
+ * than erroring on submit. Custom positions stay available; they're validated on submit.
+ * An unsupported current selection falls back to Classical.
+ */
+function setEngineOnlyVariants(engineOnly: boolean): void {
+	element_variantListPanels.forEach((panel) => {
+		let anySupported = false;
+		panel.querySelectorAll<HTMLElement>('.variant-item[data-code]').forEach((btn) => {
+			const code = btn.getAttribute('data-code')!;
+			const supported = hydrochess_card.SUPPORTED_VARIANTS.has(code);
+			btn.classList.toggle('hidden', engineOnly && !supported);
+			if (supported) anySupported = true;
+		});
+		const group = panel.getAttribute('data-group');
+		if (group === 'custom') return; // The custom panel hosts saves/ICN, never hidden.
+		document
+			.querySelector<HTMLElement>(`button[data-group="${group}"]`)
+			?.classList.toggle('hidden', engineOnly && !anySupported);
+	});
+
+	if (
+		engineOnly &&
+		selection.kind === 'preset' &&
+		!hydrochess_card.SUPPORTED_VARIANTS.has(selection.code)
+	)
+		selectVariant('Classical');
 }
 
 /** Opens the custom variant panel and refreshes saved positions. */
@@ -542,6 +573,15 @@ function handleSavePreview(
 }
 
 /**
+ * Returns the parsed VariantOptions of the current CUSTOM selection (saved position or
+ * ICN input), or null for preset selections / while the position is invalid or loading.
+ */
+function getSelectedVariantOptions(): VariantOptions | null {
+	if (selection.kind === 'preset') return null;
+	return icnResult?.isValid ? icnResult.options : null;
+}
+
+/**
  * Returns the current variant selection as an InviteVariant for the wire format,
  * or null if the selection cannot be used for an online seek (invalid ICN, local save).
  */
@@ -578,6 +618,8 @@ export default {
 	initVariantGroupDropdown,
 	initIcnValidation,
 	closeVariantDropdown,
+	setEngineOnlyVariants,
 	getInviteVariant,
+	getSelectedVariantOptions,
 	applyIcn,
 };

--- a/src/client/types/globals.d.ts
+++ b/src/client/types/globals.d.ts
@@ -1,9 +1,9 @@
 // src/client/types/globals.d.ts
 
 import type { Player } from '../../shared/chess/util/typeutil.js';
-import type { StaticGameSetup } from '../../shared/types.js';
 import type { TranslationsObject } from '../../types/translations.js';
 import type { ScriptTranslations } from '../../shared/types/script-translations.js';
+import type { EngineGamePageInfo, StaticGameSetup } from '../../shared/types.js';
 
 /**
  * Legacy i18next-era client translations. Backs the global `translations` object
@@ -89,6 +89,12 @@ declare global {
 		isLive: boolean;
 		/** The viewer's color, SSR-resolved from their cookie identity. Undefined for spectators. */
 		role?: Player;
+		/** Present only for a live engine (vs computer) game — played locally against the wasm engine. */
+		engineGame?: EngineGamePageInfo;
+		/** Hashed URL of the engine's worker script (from the asset manifest). Present with {@link engineGame}. */
+		engineWorkerUrl?: string;
+		/** Content-versioned URL of the unbundled engine glue (`/engine/<hash>/hydrochess_wasm.js`). Present with {@link engineGame}. */
+		engineUrl?: string;
 	} & StaticGameSetup;
 
 	/** SSR→client data for the analysis page (/analysis/:id?), injected by analysis.njk. */

--- a/src/server/api/EngineGameAPI.ts
+++ b/src/server/api/EngineGameAPI.ts
@@ -1,0 +1,218 @@
+// src/server/api/EngineGameAPI.ts
+
+/**
+ * API endpoints for engine (vs computer) games, played locally in the owner's
+ * browser but recorded server-side with a real game id like PvP games:
+ *
+ * * `POST   /api/engine-game`              — create a game, returns its id.
+ * * `GET    /api/engine-game/:id`          — the owner's resumable live-game state.
+ * * `POST   /api/engine-game/:id/progress` — per-move state sync.
+ * * `POST   /api/engine-game/:id/conclude` — log the finished game permanently.
+ */
+
+import type { Request, Response } from 'express';
+import type { AuthSeekVariant } from '../../shared/types.js';
+import type { EngineGamesRecord } from '../database/engineGamesManager.js';
+
+import clockutil from '../../shared/chess/util/clockutil.js';
+import { engineDictionary } from '../../shared/chess/engines/engine.js';
+import { POSITION_STRING_THRESHOLD } from '../../shared/chess/variants/servervalidation.js';
+import compression, { CompressionMode } from '../../shared/util/compression.js';
+import {
+	CreateEngineGameBodySchema,
+	ConcludeEngineGameBodySchema,
+	EngineGameProgressBodySchema,
+} from '../../shared/types.js';
+
+import { logZodError } from '../utility/zodlogger.js';
+import { decodeGameId } from '../database/gamesManager.js';
+import { logEventsAndPrint } from '../middleware/logEvents.js';
+import { issueUniqueGameId } from '../game/gamemanager/gamemanager.js';
+import { getSavedPositionICN } from '../database/editorSavesManager.js';
+import { validateIcnSeekContent } from '../game/seeksmanager/createseek.js';
+import {
+	createEngineGame,
+	getLiveEngineGame,
+	isEngineGameOwner,
+	concludeEngineGame,
+	recordEngineGameProgress,
+	produceEngineGameResumeState,
+} from '../game/gamemanager/enginegames.js';
+
+// Helpers -----------------------------------------------------------------------------------
+
+/**
+ * Resolves the live engine game named by the URL and asserts the requester owns it.
+ * Sends the appropriate error response and returns `undefined` on any failure.
+ */
+function resolveOwnedLiveEngineGame(req: Request, res: Response): EngineGamesRecord | undefined {
+	const id = decodeGameId(req.params['id']!);
+	if (id === undefined) {
+		res.status(400).json({ message: 'Invalid game id.' });
+		return undefined;
+	}
+
+	const row = getLiveEngineGame(id);
+	if (row === undefined) {
+		res.status(404).json({ message: 'No such live engine game.' });
+		return undefined;
+	}
+
+	if (!isEngineGameOwner(row, req.memberInfo!)) {
+		res.status(403).json({ message: 'You are not a participant of this engine game.' });
+		return undefined;
+	}
+
+	return row;
+}
+
+// API Endpoints -----------------------------------------------------------------------------
+
+/** `POST /api/engine-game` — creates an engine game, responding `{ id }`. */
+async function postCreateEngineGame(req: Request, res: Response): Promise<void> {
+	const memberInfo = req.memberInfo!;
+	// The owner must be identifiable to resume/conclude the game later.
+	if (!memberInfo.signedIn && memberInfo.browser_id === undefined) {
+		res.status(403).json({ message: 'Cannot identify you. Are cookies enabled?' });
+		return;
+	}
+
+	const parseResult = CreateEngineGameBodySchema.safeParse(req.body);
+	if (!parseResult.success) {
+		// Not localized: unreachable via the client, only a hand-crafted request lands here.
+		res.status(400).json({ message: 'The request was invalid.' });
+		logZodError(req.body, parseResult.error, 'Invalid create engine game request body.');
+		return;
+	}
+	const body = parseResult.data;
+
+	if (!clockutil.isTimedControlValid(body.timeControl)) {
+		res.status(400).json({ message: 'Invalid clock value.' });
+		return;
+	}
+	if (body.strengthLevel > engineDictionary[body.engine].maxStrengthLevel) {
+		res.status(400).json({ message: 'Invalid engine strength level.' });
+		return;
+	}
+
+	try {
+		// Resolve cloudSave variants to plain ICN (mirrors seek creation).
+		let variant: AuthSeekVariant;
+		if (body.variant.kind === 'cloudSave') {
+			if (!memberInfo.signedIn) {
+				res.status(401).json({ message: req.t.responses.seeks.cloud_requires_sign_in });
+				return;
+			}
+			const record = getSavedPositionICN(body.variant.name, memberInfo.user_id);
+			if (record === undefined) {
+				res.status(404).json({ message: req.t.responses.seeks.cloud_not_found });
+				return;
+			}
+			// Skip decompression if the compressed payload is already too large to be legal.
+			if (record.icn.length > POSITION_STRING_THRESHOLD) {
+				res.status(400).json({ message: req.t.shared.position_errors.position_too_large });
+				return;
+			}
+			const position = await compression.decompressString(
+				record.icn,
+				record.compression as CompressionMode,
+			);
+			variant = { kind: 'custom', position };
+		} else {
+			variant = body.variant;
+		}
+
+		// Validate a custom position's legality.
+		if (variant.kind === 'custom') {
+			const illegalReason = validateIcnSeekContent(variant.position);
+			if (illegalReason !== null) {
+				res.status(400).json({
+					message: req.t.shared.position_errors[illegalReason] ?? illegalReason,
+				});
+				return;
+			}
+		}
+
+		const id = issueUniqueGameId();
+		createEngineGame(id, memberInfo, {
+			variant,
+			timeControl: body.timeControl,
+			color: body.color,
+			engine: body.engine,
+			strengthLevel: body.strengthLevel,
+		});
+		res.status(201).json({ id });
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logEventsAndPrint(`Error creating engine game: ${message}`, 'errLog');
+		res.status(500).json({ message: 'A server error occurred. Please try again.' });
+	}
+}
+
+/** `GET /api/engine-game/:id` — the owner's resumable state of a live engine game. */
+function getEngineGameState(req: Request, res: Response): void {
+	try {
+		const row = resolveOwnedLiveEngineGame(req, res);
+		if (row === undefined) return;
+		res.json(produceEngineGameResumeState(row));
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logEventsAndPrint(`Error fetching engine game state: ${message}`, 'errLog');
+		res.status(500).json({ message: 'A server error occurred. Please try again.' });
+	}
+}
+
+/** `POST /api/engine-game/:id/progress` — records the owner's per-move state sync. */
+function postEngineGameProgress(req: Request, res: Response): void {
+	try {
+		const row = resolveOwnedLiveEngineGame(req, res);
+		if (row === undefined) return;
+
+		const parseResult = EngineGameProgressBodySchema.safeParse(req.body);
+		if (!parseResult.success) {
+			// Not localized: unreachable via the client, only a hand-crafted request lands here.
+			res.status(400).json({ message: 'The request was invalid.' });
+			logZodError(req.body, parseResult.error, 'Invalid engine game progress request body.');
+			return;
+		}
+
+		recordEngineGameProgress(row.game_id, parseResult.data);
+		res.status(204).end();
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logEventsAndPrint(`Error recording engine game progress: ${message}`, 'errLog');
+		res.status(500).json({ message: 'A server error occurred. Please try again.' });
+	}
+}
+
+/** `POST /api/engine-game/:id/conclude` — logs the finished game to the permanent tables. */
+function postEngineGameConclusion(req: Request, res: Response): void {
+	try {
+		const row = resolveOwnedLiveEngineGame(req, res);
+		if (row === undefined) return;
+
+		const parseResult = ConcludeEngineGameBodySchema.safeParse(req.body);
+		if (!parseResult.success) {
+			// Not localized: unreachable via the client, only a hand-crafted request lands here.
+			res.status(400).json({ message: 'The request was invalid.' });
+			logZodError(req.body, parseResult.error, 'Invalid engine game conclusion request body.'); // prettier-ignore
+			return;
+		}
+
+		const logged = concludeEngineGame(row, parseResult.data);
+		res.json({ logged });
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logEventsAndPrint(`Error concluding engine game ${req.params['id']}: ${message}`, 'errLog');
+		res.status(500).json({ message: 'A server error occurred. Please try again.' });
+	}
+}
+
+// Exports -----------------------------------------------------------------------------------
+
+export default {
+	postCreateEngineGame,
+	getEngineGameState,
+	postEngineGameProgress,
+	postEngineGameConclusion,
+};

--- a/src/server/controllers/gamePageController.ts
+++ b/src/server/controllers/gamePageController.ts
@@ -8,9 +8,10 @@
  */
 
 import type { Request } from 'express';
+import type { MemberInfo } from '../types.js';
 import type { SpeedCategory } from '../../shared/chess/util/clockutil.js';
 import type { Player, PlayerGroup } from '../../shared/chess/util/typeutil.js';
-import type { StaticGameSetup, StaticGameState } from '../../shared/types.js';
+import type { EngineGamePageInfo, StaticGameSetup, StaticGameState } from '../../shared/types.js';
 
 import timeutil from '../../shared/util/timeutil.js';
 import moveutil from '../../shared/chess/util/moveutil.js';
@@ -28,6 +29,12 @@ import {
 	produceDeadStaticGameState,
 	resolveDeadParticipantColor,
 } from '../game/gamemanager/deadgamestate.js';
+import {
+	getLiveEngineGame,
+	isEngineGameOwner,
+	produceEngineGameStaticState,
+	resolveDeadEngineGameParticipantColor,
+} from '../game/gamemanager/enginegames.js';
 
 /** Display-ready static game-meta fields, precomputed since Nunjucks can't call the shared utils. */
 export interface GameMetaViewModel {
@@ -68,7 +75,13 @@ export interface GameMetaViewModel {
 /** The full render context for `game.njk`. */
 interface GamePageState {
 	/** Includes all static info about the game. */
-	gamePageData: { id: number; isLive: boolean; role?: Player } & StaticGameSetup;
+	gamePageData: {
+		id: number;
+		isLive: boolean;
+		role?: Player;
+		/** Present only for a live engine (vs computer) game — played locally by the owner. */
+		engineGame?: EngineGamePageInfo;
+	} & StaticGameSetup;
 	meta: GameMetaViewModel;
 }
 
@@ -81,12 +94,13 @@ export function getGamePageState(req: Request): GamePageState | undefined {
 	const id = decodeGameId(req.params['id']!);
 	if (id === undefined) return undefined; // Malformed id
 
+	const memberInfo = req.memberInfo!;
+
 	const resolved = produceStaticGameState(id);
-	if (resolved === undefined) return undefined; // Game doesn't exist
+	if (resolved === undefined) return getLiveEngineGamePageState(id, memberInfo, req); // Not a PvP/logged game — maybe a live engine game.
 	const { state, game, ratingChanges } = resolved; // game is defined if live
 
 	// Resolve the viewer's color (board orientation + role); undefined => spectator (white POV).
-	const memberInfo = req.memberInfo!;
 	let role: Player | undefined;
 	let resignable: boolean = false;
 	if (game) {
@@ -98,8 +112,11 @@ export function getGamePageState(req: Request): GamePageState | undefined {
 		}
 		resignable = moveutil.isGameResignable(game);
 	} else if (memberInfo.signedIn) {
-		// Dead games match members only (dead guests aren't identifiable).
+		// Dead games match members only (dead guests aren't identifiable) —
+		// except engine games, whose record retains the guest owner's browser id.
 		role = resolveDeadParticipantColor(id, memberInfo.user_id);
+	} else {
+		role = resolveDeadEngineGameParticipantColor(id, memberInfo);
 	}
 
 	return {
@@ -112,6 +129,38 @@ export function getGamePageState(req: Request): GamePageState | undefined {
 			timeCreated: state.timeCreated,
 		},
 		meta: buildGameMetaViewModel(state, ratingChanges, role, resignable, req),
+	};
+}
+
+/**
+ * Resolves the render state for a LIVE engine (vs computer) game, or `undefined` if the id
+ * names none — or the viewer isn't its owner (only the owner can open a live engine game;
+ * once concluded it's a normal dead game anyone can view).
+ * @throws If a database error occurs.
+ */
+function getLiveEngineGamePageState(
+	id: number,
+	memberInfo: MemberInfo,
+	req: Request,
+): GamePageState | undefined {
+	const row = getLiveEngineGame(id);
+	if (row === undefined) return undefined;
+	if (!isEngineGameOwner(row, memberInfo)) return undefined;
+
+	const { state, engineGame, resignable } = produceEngineGameStaticState(row);
+	const role = row.player_color as Player;
+
+	return {
+		gamePageData: {
+			id,
+			isLive: false, // No socket — the game runs locally in the owner's browser.
+			role,
+			engineGame,
+			variant: state.variant,
+			timeControl: state.timeControl,
+			timeCreated: state.timeCreated,
+		},
+		meta: buildGameMetaViewModel(state, undefined, role, resignable, req),
 	};
 }
 
@@ -134,11 +183,12 @@ export function getDeadGameViewState(
 	const dead = produceDeadStaticGameState(id);
 	if (dead === undefined) return undefined; // Game not in the database
 
-	// Resolve the viewer's color for board orientation; dead guests aren't identifiable.
+	// Resolve the viewer's color for board orientation; dead guests aren't
+	// identifiable — except engine-game owners (their browser id is retained).
 	const memberInfo = req.memberInfo!;
 	const role = memberInfo.signedIn
 		? resolveDeadParticipantColor(id, memberInfo.user_id)
-		: undefined;
+		: resolveDeadEngineGameParticipantColor(id, memberInfo);
 
 	return {
 		...(role !== undefined && { role }),

--- a/src/server/database/cleanupTasks.ts
+++ b/src/server/database/cleanupTasks.ts
@@ -9,9 +9,13 @@ import db from './database.js';
 import { logEventsAndPrint } from '../middleware/logEvents.js';
 import { refreshTokenGracePeriodMillis } from '../controllers/authenticationTokens/tokenSigner.js';
 import { deleteExpiredPendingRegistrations } from './pendingRegistrationManager.js';
+import { deleteStaleUnconcludedEngineGames } from './engineGamesManager.js';
 
 const CLEANUP_INTERVAL_MS = 1000 * 60 * 60 * 24; // 24 hours
 // const CLEANUP_INTERVAL_MS = 1000 * 20; // 20 seconds for dev testing
+
+/** How long an unconcluded (abandoned mid-game) engine game is kept resumable. */
+const ENGINE_GAME_RETENTION_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
 
 function startPeriodicDatabaseCleanupTasks(): void {
 	performCleanupTasks(); // Run immediately to clean up now.
@@ -23,6 +27,7 @@ function performCleanupTasks(): void {
 	deleteExpiredPasswordResetTokens();
 	cleanUpExpiredRefreshTokens();
 	deleteExpiredPendingRegistrations();
+	deleteStaleEngineGames();
 }
 
 // ========================================================
@@ -93,6 +98,19 @@ function cleanUpExpiredRefreshTokens(): void {
 	} catch (error) {
 		const errorMessage =
 			'Failed to delete expired refresh tokens: ' +
+			(error instanceof Error ? error.message : String(error));
+		logEventsAndPrint(errorMessage, 'errLog');
+	}
+}
+
+/** Deletes engine games abandoned mid-game and untouched past the retention window. */
+function deleteStaleEngineGames(): void {
+	try {
+		const deleted = deleteStaleUnconcludedEngineGames(Date.now() - ENGINE_GAME_RETENTION_MS);
+		if (deleted > 0) console.log(`Cleanup: Deleted ${deleted} stale engine games.`);
+	} catch (error) {
+		const errorMessage =
+			'Failed to delete stale engine games: ' +
 			(error instanceof Error ? error.message : String(error));
 		logEventsAndPrint(errorMessage, 'errLog');
 	}

--- a/src/server/database/databaseTables.ts
+++ b/src/server/database/databaseTables.ts
@@ -113,6 +113,24 @@ const allLiveGamesColumns: string[] = [
 	'both_disconnected_end_time',
 ];
 
+/** All columns of the engine_games table. */
+const allEngineGamesColumns: string[] = [
+	'game_id',
+	'time_created',
+	'user_id',
+	'browser_id',
+	'player_color',
+	'engine',
+	'strength_level',
+	'variant',
+	'position',
+	'clock',
+	'moves',
+	'clock_white',
+	'clock_black',
+	'last_updated',
+];
+
 /** All columns of the live_player_games table. */
 const allLivePlayerGamesColumns: string[] = [
 	'game_id',
@@ -376,6 +394,29 @@ function generateTables(): void {
 		);
 	`);
 	db.run(`CREATE INDEX IF NOT EXISTS idx_live_player_games_game ON live_player_games (game_id);`);
+
+	// Engine Games table — one row per game against an engine, created at game start.
+	// The engine plays locally in the owner's browser; the server only records state.
+	// The row is KEPT after conclusion (moves blanked) as the permanent record of the
+	// engine participant + settings, complementing the games/player_games tables.
+	db.run(`
+		CREATE TABLE IF NOT EXISTS engine_games (
+			game_id        INTEGER PRIMARY KEY,
+			time_created   INTEGER NOT NULL,
+			user_id        INTEGER, -- The human owner, if signed in
+			browser_id     TEXT NOT NULL, -- The human owner's browser id
+			player_color   INTEGER NOT NULL, -- The human's color. 1 => White  2 => Black
+			engine         TEXT NOT NULL,
+			strength_level INTEGER NOT NULL,
+			variant        TEXT, -- preset variant code, or null for a custom-position game (see position)
+			position       TEXT, -- custom game's start position; null for preset games (complementary to variant)
+			clock          TEXT NOT NULL,
+			moves          TEXT NOT NULL DEFAULT '', -- Blanked once the game is logged to the games table
+			clock_white    INTEGER, -- ms remaining snapshots; null for untimed games
+			clock_black    INTEGER,
+			last_updated   INTEGER NOT NULL -- Epoch ms of the last state sync; drives the stale-game purge
+		);
+	`);
 }
 
 function initDatabase(): void {
@@ -649,6 +690,7 @@ export {
 	allRatingAbuseColumns,
 	allLiveGamesColumns,
 	allLivePlayerGamesColumns,
+	allEngineGamesColumns,
 	initDatabase,
 	generateTables,
 	clearAllTables,

--- a/src/server/database/engineGamesManager.ts
+++ b/src/server/database/engineGamesManager.ts
@@ -1,0 +1,163 @@
+// src/server/database/engineGamesManager.ts
+
+/**
+ * This script manages the engine_games table: one row per game against an engine,
+ * created at game start. The engine plays locally in the owner's browser; the server
+ * only records state (for mid-game resume) and, on conclusion, the row is kept
+ * (moves blanked) as the permanent record of the engine participant + settings.
+ */
+
+import jsutil from '../../shared/util/jsutil.js';
+
+import db, { dbCall } from './database.js';
+import { allEngineGamesColumns } from './databaseTables.js';
+
+// Types ----------------------------------------------------------------------------------------------
+
+/** Structure of a complete engine_games record. */
+export interface EngineGamesRecord {
+	game_id: number;
+	time_created: number;
+	/** The human owner's user id, if signed in. */
+	user_id: number | null;
+	/** The human owner's browser id. */
+	browser_id: string;
+	/** The human's color. 1 => White  2 => Black */
+	player_color: number;
+	engine: string;
+	strength_level: number;
+	/**
+	 * Preset variant code, or null for a custom-position
+	 * game (its start position is in `position`).
+	 */
+	variant: string | null;
+	/** A custom game's start position; null for preset games (complementary to `variant`). */
+	position: string | null;
+	clock: string;
+	/** Compact ICN moves with clock stamps. Blanked once the game is logged to the games table. */
+	moves: string;
+	/** Ms remaining snapshots; null for untimed games. */
+	clock_white: number | null;
+	clock_black: number | null;
+	/** Epoch ms of the last state sync; drives the stale-game purge. */
+	last_updated: number;
+}
+
+type EngineGamesColumn = keyof EngineGamesRecord;
+
+// Methods --------------------------------------------------------------------------------------------
+
+/**
+ * Checks if a given game_id exists in the engine_games table.
+ * @throws If a database error occurs.
+ */
+export function isEngineGameIdTaken(game_id: number): boolean {
+	const query = 'SELECT EXISTS(SELECT 1 FROM engine_games WHERE game_id = ?) AS found';
+	const row = dbCall(
+		() => db.get<{ found: 0 | 1 }>(query, [game_id]),
+		`Error checking if engine game_id "${game_id}" is taken`,
+	);
+	return Boolean(row?.found);
+}
+
+/**
+ * Inserts a new engine game row into the database.
+ * @throws If a database error occurs.
+ */
+export function insertEngineGame(record: EngineGamesRecord): void {
+	const query = `
+		INSERT INTO engine_games (
+			game_id, time_created, user_id, browser_id, player_color, engine,
+			strength_level, variant, position, clock, moves, clock_white,
+			clock_black, last_updated
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`;
+	dbCall(
+		() =>
+			db.run(query, [
+				record.game_id,
+				record.time_created,
+				record.user_id,
+				record.browser_id,
+				record.player_color,
+				record.engine,
+				record.strength_level,
+				record.variant,
+				record.position,
+				record.clock,
+				record.moves,
+				record.clock_white,
+				record.clock_black,
+				record.last_updated,
+			]),
+		`Error inserting engine game ${record.game_id}`,
+	);
+}
+
+/**
+ * Fetches specified columns of a single engine game.
+ * @returns An object containing the requested columns, or undefined if no such row exists.
+ * @throws If invalid arguments are provided, or if a database error occurs.
+ */
+export function getEngineGameData<K extends EngineGamesColumn>(
+	game_id: number,
+	columns: K[],
+): Pick<EngineGamesRecord, K> | undefined {
+	return dbCall(() => {
+		if (!columns.every((column) => allEngineGamesColumns.includes(column)))
+			throw new Error(
+				`Invalid columns requested from engine_games table: ${jsutil.ensureJSONString(columns)}`,
+			);
+		const query = `SELECT ${columns.join(', ')} FROM engine_games WHERE game_id = ?`;
+		return db.get<Pick<EngineGamesRecord, K>>(query, [game_id]);
+	}, `Error when getting engine game data of game_id ${game_id}`);
+}
+
+/**
+ * Updates specific columns of an engine game. `game_id` is not updatable.
+ * @throws If invalid arguments are provided, or if a database error occurs.
+ */
+export function updateEngineGame(game_id: number, updates: Partial<EngineGamesRecord>): void {
+	dbCall(() => {
+		const entries = Object.entries(updates);
+		if (entries.length === 0)
+			throw new Error(`Empty updates provided when updating engine game ${game_id}! Received: ${jsutil.ensureJSONString(updates)}`); // prettier-ignore
+		if (!entries.every(([col]) => col !== 'game_id' && allEngineGamesColumns.includes(col)))
+			throw new Error(`Invalid columns provided when updating engine game ${game_id}! Received: ${jsutil.ensureJSONString(updates)}`); // prettier-ignore
+
+		const setClauses = entries.map(([col]) => `${col} = ?`).join(', ');
+		const values = entries.map(([, val]) => val);
+		db.run(`UPDATE engine_games SET ${setClauses} WHERE game_id = ?`, [...values, game_id]);
+	}, `Error updating engine game ${game_id}`);
+}
+
+/**
+ * Deletes an engine game row. Used when a game is abandoned/aborted
+ * with zero moves (never logged, so no record should remain).
+ * @throws If a database error occurs.
+ */
+export function deleteEngineGame(game_id: number): void {
+	dbCall(
+		() => db.run('DELETE FROM engine_games WHERE game_id = ?', [game_id]),
+		`Error deleting engine game ${game_id}`,
+	);
+}
+
+/**
+ * Deletes engine games that were never concluded (no games-table row) and haven't
+ * been touched since the cutoff — abandoned mid-game and never resumed.
+ * Concluded games' rows are kept forever (they name the engine participant).
+ * @returns The number of rows deleted.
+ * @throws If a database error occurs.
+ */
+export function deleteStaleUnconcludedEngineGames(cutoffEpochMillis: number): number {
+	const query = `
+		DELETE FROM engine_games
+		WHERE last_updated < ?
+		  AND game_id NOT IN (SELECT game_id FROM games)
+	`;
+	return dbCall(
+		() => db.run(query, [cutoffEpochMillis]).changes,
+		'Error deleting stale engine games',
+	);
+}

--- a/src/server/database/gamesManager.ts
+++ b/src/server/database/gamesManager.ts
@@ -8,6 +8,7 @@ import uuid from '../../shared/util/uuid.js';
 import jsutil from '../../shared/util/jsutil.js';
 
 import db, { dbCall } from './database.js';
+import { isEngineGameIdTaken } from './engineGamesManager.js';
 import { allGamesColumns, game_id_upper_cap } from './databaseTables.js';
 
 // Types ----------------------------------------------------------------------------------------------
@@ -62,7 +63,7 @@ export function decodeGameId(idStr: string): number | undefined {
 }
 
 /**
- * Generates a game_id **UNIQUE** to all other game ids in the games table.
+ * Generates a game_id **UNIQUE** to all other game ids in the games AND engine_games tables.
  * @returns - A unique game_id.
  * @throws If a database error occurs.
  */
@@ -70,7 +71,7 @@ export function genUniqueGameID(): number {
 	let id: number;
 	do {
 		id = generateRandomGameId();
-	} while (isGameIdTaken(id));
+	} while (isGameIdTaken(id) || isEngineGameIdTaken(id));
 	return id;
 }
 

--- a/src/server/game/gamemanager/deadgamestate.ts
+++ b/src/server/game/gamemanager/deadgamestate.ts
@@ -24,6 +24,7 @@ import { players } from '../../../shared/chess/util/typeutil.js';
 import metadatautil from '../../../shared/chess/util/metadatautil.js';
 
 import { getGameData } from '../../database/gamesManager.js';
+import { getEngineParticipant } from './enginegames.js';
 import { getPlayerGamesOfGame } from '../../database/playerGamesManager.js';
 import { getMemberDataByCriteria } from '../../database/memberManager.js';
 import { UNCERTAIN_LEADERBOARD_RD } from './ratingcalculation.js';
@@ -63,7 +64,7 @@ export function produceDeadStaticGameState(
 	if (game === undefined) return undefined;
 	const playerRows = getPlayerGamesOfGame(game_id, [...STATIC_PLAYER_COLUMNS, 'elo_change_from_game']); // prettier-ignore
 
-	const state = assembleStaticGameState(game, playerRows);
+	const state = assembleStaticGameState(game_id, game, playerRows);
 
 	/** Per signed-in player rating delta; populated only for rated games. */
 	const ratingChanges: PlayerGroup<number> = {};
@@ -96,7 +97,7 @@ export function produceDeadGameState(game_id: number): DeadGameState | undefined
 	}
 
 	const state: DeadGameState = {
-		...assembleStaticGameState(game, playerRows),
+		...assembleStaticGameState(game_id, game, playerRows),
 		icn: game.icn,
 	};
 
@@ -106,16 +107,24 @@ export function produceDeadGameState(game_id: number): DeadGameState | undefined
 }
 
 /**
- * Maps already-fetched DB rows into the {@link StaticGameState} base. Pure (no queries
- * beyond the per-player username lookup), so both readers below share one field mapping.
+ * Maps already-fetched DB rows into the {@link StaticGameState} base,
+ * so both readers above share one field mapping.
  */
 function assembleStaticGameState(
+	game_id: number,
 	game: Pick<GamesRecord, (typeof STATIC_GAME_COLUMNS)[number]>,
 	playerRows: Pick<PlayerGamesRecord, (typeof STATIC_PLAYER_COLUMNS)[number]>[],
 ): StaticGameState {
+	// An engine game's engine has no player_games row; its sidecar record names it.
+	const engineParticipant = getEngineParticipant(game_id);
+
 	/** Per-color username container; a color absent from `playerRows` -> guest. */
 	const playerContainers: PlayerGroup<ServerUsernameContainer> = {};
 	for (const color of [players.WHITE, players.BLACK]) {
+		if (engineParticipant?.color === color) {
+			playerContainers[color] = engineParticipant.container;
+			continue;
+		}
 		const row = playerRows.find((r) => r.player_number === color);
 		if (row === undefined) {
 			// No row -> this color was a guest.

--- a/src/server/game/gamemanager/enginegames.ts
+++ b/src/server/game/gamemanager/enginegames.ts
@@ -1,0 +1,426 @@
+// src/server/game/gamemanager/enginegames.ts
+
+/**
+ * Server-side lifecycle of engine (vs computer) games. The engine runs locally in the
+ * owner's browser — the server never validates moves or runs clocks. It only:
+ *
+ * * records the game at creation (engine_games table),
+ * * stores per-move progress syncs so a mid-game refresh can resume,
+ * * on conclusion, logs the finished game to the permanent games/player_games
+ *   tables exactly like a PvP game (casual, no ratings/stats).
+ */
+
+import type { CoordsKey } from '../../../shared/chess/util/coordutil.js';
+import type { GameRules } from '../../../shared/chess/util/gamerules.js';
+import type { MemberInfo } from '../../types.js';
+import type { MoveParsed } from '../../../shared/chess/logic/icn/icnconverter.js';
+import type { VariantCode } from '../../../shared/chess/variants/variantregistry.js';
+import type { GlobalGameState } from '../../../shared/chess/logic/state.js';
+import type { MetaData, Rating } from '../../../shared/types.js';
+import type { Player, PlayerGroup } from '../../../shared/chess/util/typeutil.js';
+import type {
+	AuthSeekVariant,
+	ConcludeEngineGameBody,
+	EngineGamePageInfo,
+	EngineGameProgressBody,
+	EngineGameState,
+	ServerUsernameContainer,
+	StaticGameState,
+	TimeControl,
+} from '../../../shared/types.js';
+
+import uuid from '../../../shared/util/uuid.js';
+import timeutil from '../../../shared/util/timeutil.js';
+import clockutil from '../../../shared/chess/util/clockutil.js';
+import icnimport from '../../../shared/chess/logic/icn/icnimport.js';
+import winconutil from '../../../shared/chess/util/winconutil.js';
+import metadatautil from '../../../shared/chess/util/metadatautil.js';
+import variantcache from '../../../shared/chess/variants/variantcache.js';
+import icnconverter from '../../../shared/chess/logic/icn/icnconverter.js';
+import variantregistry from '../../../shared/chess/variants/variantregistry.js';
+import typeutil, { players as p } from '../../../shared/chess/util/typeutil.js';
+import gamefile, { LoadedVariant } from '../../../shared/chess/logic/gamefile.js';
+import { getFormattedEngineName, ValidEngine } from '../../../shared/chess/engines/engine.js';
+import {
+	VariantLeaderboards,
+	Leaderboards,
+} from '../../../shared/chess/variants/validleaderboard.js';
+
+import db from '../../database/database.js';
+import tconfig from '../../config/translationconfig.js';
+import { isGameIdTaken } from '../../database/gamesManager.js';
+import { getScriptTranslations } from '../../config/componentTranslationLoader.js';
+import { getMemberDataByCriteria } from '../../database/memberManager.js';
+import { getEloOfPlayerInLeaderboard } from '../../database/leaderboardsManager.js';
+import {
+	EngineGamesRecord,
+	insertEngineGame,
+	getEngineGameData,
+	updateEngineGame,
+	deleteEngineGame,
+} from '../../database/engineGamesManager.js';
+
+/** Display name for a player whose account was deleted (mirrors deadgamestate.ts). */
+const DELETED_USER_DISPLAY_NAME = '(Deleted User)';
+
+/** Conclusion conditions that can't occur in an engine game (they require a second human). */
+const IMPOSSIBLE_ENGINE_CONDITIONS = ['agreement', 'disconnect', 'abandonment'];
+
+// Creation ------------------------------------------------------------------------------------------
+
+/**
+ * Creates a new engine game record under the given (already issued, unique) game id.
+ * @throws If a database error occurs.
+ */
+export function createEngineGame(
+	game_id: number,
+	owner: MemberInfo,
+	options: {
+		variant: AuthSeekVariant;
+		timeControl: TimeControl;
+		/** The color the human plays. */
+		color: Player;
+		engine: ValidEngine;
+		strengthLevel: number;
+	},
+): void {
+	const now = Date.now();
+
+	// Both colors start with the base time (null clock columns = untimed).
+	const clockParts = clockutil.getMinutesAndIncrementFromClock(options.timeControl);
+	const startMillis = clockParts !== null ? timeutil.minutesToMillis(clockParts.minutes) : null;
+
+	insertEngineGame({
+		game_id,
+		time_created: now,
+		user_id: owner.signedIn ? owner.user_id : null,
+		browser_id: owner.browser_id ?? '',
+		player_color: options.color,
+		engine: options.engine,
+		strength_level: options.strengthLevel,
+		variant: options.variant.kind === 'preset' ? options.variant.code : null,
+		position: options.variant.kind === 'custom' ? options.variant.position : null,
+		clock: options.timeControl,
+		moves: '',
+		clock_white: startMillis,
+		clock_black: startMillis,
+		last_updated: now,
+	});
+}
+
+// Reads ---------------------------------------------------------------------------------------------
+
+/**
+ * Returns the full engine_games row of a LIVE (not yet concluded) engine
+ * game, or `undefined` if the id names no engine game or a concluded one.
+ * @throws If a database error occurs.
+ */
+export function getLiveEngineGame(game_id: number): EngineGamesRecord | undefined {
+	// prettier-ignore
+	const row = getEngineGameData(game_id, ['game_id', 'time_created', 'user_id', 'browser_id', 'player_color', 'engine', 'strength_level', 'variant', 'position', 'clock', 'moves', 'clock_white', 'clock_black', 'last_updated']);
+	if (row === undefined) return undefined;
+	if (isGameIdTaken(game_id)) return undefined; // Concluded — the dead-game path owns it now.
+	return row;
+}
+
+/** Whether the given viewer identity owns (is the human participant of) the engine game. */
+export function isEngineGameOwner(row: EngineGamesRecord, memberInfo: MemberInfo): boolean {
+	if (memberInfo.signedIn) return row.user_id === memberInfo.user_id;
+	return memberInfo.browser_id !== undefined && row.browser_id === memberInfo.browser_id;
+}
+
+/** The number of moves currently synced for the game. */
+function getMoveCount(row: EngineGamesRecord): number {
+	// Sync'd moves carry only [%clk] comments, so '|' only ever delimits moves.
+	return row.moves === '' ? 0 : row.moves.split('|').length;
+}
+
+/** The engine participant's username container. */
+function buildEngineUsernameContainer(
+	engine: string,
+	strengthLevel: number,
+): ServerUsernameContainer {
+	return {
+		type: 'engine',
+		username: getFormattedEngineName(engine as ValidEngine, strengthLevel),
+	};
+}
+
+/**
+ * Builds the {@link StaticGameState} of a live engine game for the game page's SSR,
+ * plus whether it's resignable (2+ plies) and the engine info for `gamePageData`.
+ * @throws If a database error occurs.
+ */
+export function produceEngineGameStaticState(row: EngineGamesRecord): {
+	state: StaticGameState;
+	engineGame: EngineGamePageInfo;
+	resignable: boolean;
+} {
+	// The human's container: username + live rating for members, guest label otherwise.
+	let humanContainer: ServerUsernameContainer;
+	if (row.user_id !== null) {
+		const member = getMemberDataByCriteria(['username'], 'user_id', row.user_id);
+		humanContainer = {
+			type: 'player',
+			username: member?.username ?? DELETED_USER_DISPLAY_NAME,
+		};
+		const leaderboardId =
+			row.variant !== null
+				? (VariantLeaderboards[row.variant as VariantCode] ?? Leaderboards.INFINITY)
+				: Leaderboards.INFINITY;
+		const rating: Rating | undefined = getEloOfPlayerInLeaderboard(row.user_id, leaderboardId);
+		if (rating) humanContainer.rating = rating;
+	} else {
+		humanContainer = { type: 'guest', username: metadatautil.GUEST_NAME_ICN_METADATA };
+	}
+
+	const humanColor = row.player_color as Player;
+	const players: PlayerGroup<ServerUsernameContainer> = {
+		[humanColor]: humanContainer,
+		[typeutil.invertPlayer(humanColor)]: buildEngineUsernameContainer(row.engine, row.strength_level), // prettier-ignore
+	};
+
+	return {
+		state: {
+			rated: false,
+			variant:
+				row.variant !== null
+					? { kind: 'preset', code: row.variant as VariantCode }
+					: { kind: 'custom' },
+			timeControl: row.clock as TimeControl,
+			timeCreated: row.time_created,
+			players,
+		},
+		engineGame: {
+			engine: row.engine as ValidEngine,
+			strengthLevel: row.strength_level,
+		},
+		resignable: getMoveCount(row) >= 2,
+	};
+}
+
+/** Builds the owner's resumable {@link EngineGameState} (the `GET /api/engine-game/:id` payload). */
+export function produceEngineGameResumeState(row: EngineGamesRecord): EngineGameState {
+	const state: EngineGameState = { moves: row.moves };
+	if (row.position !== null) state.position = row.position;
+	if (row.clock_white !== null && row.clock_black !== null)
+		state.clocks = { [p.WHITE]: row.clock_white, [p.BLACK]: row.clock_black };
+	return state;
+}
+
+// Progress & Conclusion -------------------------------------------------------------------------------
+
+/**
+ * Records a mid-game state sync from the owner's client.
+ * @throws If a database error occurs.
+ */
+export function recordEngineGameProgress(game_id: number, body: EngineGameProgressBody): void {
+	updateEngineGame(game_id, {
+		moves: body.moves,
+		clock_white: body.clocks?.[p.WHITE] ?? null,
+		clock_black: body.clocks?.[p.BLACK] ?? null,
+		last_updated: Date.now(),
+	});
+}
+
+/**
+ * Concludes an engine game: logs it to the permanent games/player_games tables (casual —
+ * no ratings, leaderboards, or player stats), then blanks the live-state columns. A game
+ * concluded with zero moves is never stored — its record is deleted entirely instead.
+ * @returns Whether the game was logged (false = zero moves, record deleted).
+ * @throws If the conclusion is impossible for an engine game, the moves/position fail to
+ * parse, or a database error occurs (rolled back).
+ */
+export function concludeEngineGame(row: EngineGamesRecord, body: ConcludeEngineGameBody): boolean {
+	if (IMPOSSIBLE_ENGINE_CONDITIONS.includes(body.gameConclusion.condition))
+		throw Error(`Impossible engine game conclusion: ${body.gameConclusion.condition}`);
+
+	const moves: MoveParsed[] = icnconverter.parseShortFormMoves(body.moves);
+	// An unparseable non-empty moves string must not masquerade as a zero-move abort.
+	if (body.moves !== '' && moves.length === 0)
+		throw Error('Engine game conclusion moves string failed to parse.');
+	if (moves.length === 0) {
+		deleteEngineGame(row.game_id); // Zero-move games are never stored.
+		return false;
+	}
+
+	const { victor, condition } = body.gameConclusion;
+	const now = Date.now();
+
+	// Resolve the game's rules + (for custom games) start position.
+	let gameRules: GameRules;
+	let fullMove = 1;
+	let position: Map<CoordsKey, number> | undefined;
+	let state_global: Partial<GlobalGameState>;
+	if (row.variant !== null) {
+		const variant: LoadedVariant = {
+			code: row.variant as VariantCode,
+			mod: variantcache.getModule(row.variant as VariantCode),
+			dateTimestamp: row.time_created,
+		};
+		gameRules = gamefile.initGame(row.clock as TimeControl, row.time_created, variant).gameRules; // prettier-ignore
+		state_global = { moveRuleState: gameRules.moveRule !== undefined ? 0 : undefined };
+	} else {
+		const longformOut = icnconverter.ShortToLong_Format(row.position!);
+		const variantOptions = icnimport.variantOptionsFromLongFormat(longformOut);
+		gameRules = variantOptions.gameRules;
+		fullMove = variantOptions.fullMove;
+		position = variantOptions.position;
+		state_global = variantOptions.state_global;
+	}
+
+	// The `games.termination` column stores the raw condition code (e.g. "resignation") — the
+	// dead-game reader feeds it straight back as `gameConclusion.condition`. The ICN metadata
+	// gets the English display string. (Mirrors the PvP gamelogger split.)
+	const terminationEnglish = winconutil.getTerminationInEnglish(gameRules, condition);
+	const metadata = buildEngineGameMetadata(row, victor, terminationEnglish);
+	const icn = icnconverter.LongToShort_Format(
+		{ metadata, gameRules, fullMove, position, moves, state_global },
+		{
+			skipPosition: row.variant !== null, // Custom games embed their start position.
+			compact: true,
+			spaces: false,
+			comments: true, // Carries the clock stamps.
+			make_new_lines: false,
+			move_numbers: false,
+		},
+	);
+
+	const { base_time_seconds, increment_seconds } = clockutil.splitTimeControl(row.clock as TimeControl); // prettier-ignore
+	const humanColor = row.player_color as Player;
+	const humanClock = body.clocks?.[humanColor];
+
+	const transaction = db.transaction(() => {
+		db.run(
+			`INSERT INTO games (
+				game_id, date, base_time_seconds, increment_seconds, variant, rated,
+				leaderboard_id, private, result, termination, move_count,
+				time_duration_millis, icn
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				row.game_id,
+				timeutil.timestampToSqlite(row.time_created),
+				base_time_seconds,
+				increment_seconds,
+				row.variant,
+				0, // Engine games are always casual.
+				row.variant !== null ? (VariantLeaderboards[row.variant as VariantCode] ?? null) : null, // prettier-ignore
+				0, // Public.
+				metadata.Result!,
+				condition, // Raw code; the dead-game reader feeds it back as gameConclusion.condition.
+				moves.length,
+				now - row.time_created,
+				icn,
+			],
+		);
+
+		// The human gets a player_games row if signed in; the engine never does.
+		if (row.user_id !== null) {
+			db.run(
+				`INSERT INTO player_games (
+					user_id, game_id, player_number, score, clock_at_end_millis
+				) VALUES (?, ?, ?, ?, ?)`,
+				[
+					row.user_id,
+					row.game_id,
+					humanColor,
+					victor === undefined ? null : victor === humanColor ? 1 : victor === null ? 0.5 : 0, // prettier-ignore
+					humanClock ?? null,
+				],
+			);
+		}
+
+		// The row remains as the permanent record of the engine participant + settings;
+		// the game state now lives in the games table's ICN.
+		updateEngineGame(row.game_id, {
+			moves: '',
+			clock_white: null,
+			clock_black: null,
+			last_updated: now,
+		});
+	});
+	transaction();
+
+	return true;
+}
+
+/** Assembles the ICN {@link MetaData} of a concluded engine game. Always English. */
+function buildEngineGameMetadata(
+	row: EngineGamesRecord,
+	victor: Player | null | undefined,
+	termination: string,
+): MetaData {
+	const scriptT = getScriptTranslations('shared', tconfig.DEFAULT_LANGUAGE); // Game metadata should only ever be in English
+	const variantEnglishName = variantregistry.getVariantName(
+		row.variant as VariantCode | null,
+		scriptT,
+	);
+	const { UTCDate, UTCTime } = timeutil.convertTimestampToUTCDateUTCTime(row.time_created);
+
+	// The human's display name; the engine's formatted name fills the other color.
+	let humanName: string = metadatautil.GUEST_NAME_ICN_METADATA;
+	if (row.user_id !== null) {
+		const member = getMemberDataByCriteria(['username'], 'user_id', row.user_id);
+		humanName = member?.username ?? DELETED_USER_DISPLAY_NAME;
+	}
+	const engineName = buildEngineUsernameContainer(row.engine, row.strength_level).username;
+	const humanIsWhite = row.player_color === p.WHITE;
+
+	const metadata: MetaData = {
+		Event: `Casual ${variantEnglishName} infinite chess game against an engine`,
+		Site: 'https://www.infinitechess.org/',
+		Round: '-',
+		White: humanIsWhite ? humanName : engineName,
+		Black: humanIsWhite ? engineName : humanName,
+		TimeControl: row.clock as TimeControl,
+		UTCDate,
+		UTCTime,
+		Result: metadatautil.getResultFromVictor(victor),
+		Termination: termination,
+	};
+	if (row.variant !== null) metadata.Variant = variantEnglishName;
+	if (row.user_id !== null) {
+		const idTag = uuid.base10ToBase62(row.user_id);
+		if (humanIsWhite) metadata.WhiteID = idTag;
+		else metadata.BlackID = idTag;
+	}
+
+	return metadata;
+}
+
+// Dead-game support -----------------------------------------------------------------------------------
+
+/**
+ * Returns the engine participant of an engine game — its color and username container —
+ * or `undefined` if the game wasn't an engine game. Lets the dead-game readers name
+ * the engine instead of falling back to a guest.
+ * @throws If a database error occurs.
+ */
+export function getEngineParticipant(
+	game_id: number,
+): { color: Player; container: ServerUsernameContainer } | undefined {
+	const row = getEngineGameData(game_id, ['player_color', 'engine', 'strength_level']);
+	if (row === undefined) return undefined;
+	return {
+		color: typeutil.invertPlayer(row.player_color as Player),
+		container: buildEngineUsernameContainer(row.engine, row.strength_level),
+	};
+}
+
+/**
+ * Returns the color a viewer played in a concluded engine game, or `undefined` if they
+ * weren't its owner. Unlike PvP games, engine games can identify a dead GUEST owner,
+ * since the engine_games row retains the browser id.
+ * @throws If a database error occurs.
+ */
+export function resolveDeadEngineGameParticipantColor(
+	game_id: number,
+	memberInfo: MemberInfo,
+): Player | undefined {
+	const row = getEngineGameData(game_id, ['user_id', 'browser_id', 'player_color']);
+	if (row === undefined) return undefined;
+	const isOwner = memberInfo.signedIn
+		? row.user_id === memberInfo.user_id
+		: memberInfo.browser_id !== undefined && row.browser_id === memberInfo.browser_id;
+	return isOwner ? (row.player_color as Player) : undefined;
+}

--- a/src/server/game/gamemanager/gamemanager.ts
+++ b/src/server/game/gamemanager/gamemanager.ts
@@ -720,6 +720,7 @@ function restoreLiveGames(): void {
 export {
 	activeGames,
 	createGame,
+	issueUniqueGameId,
 	isMemberInSomeActiveGame,
 	unsubSocketParticipantFromGame,
 	unsubSocketSpectatorFromGame,

--- a/src/server/game/seeksmanager/createseek.ts
+++ b/src/server/game/seeksmanager/createseek.ts
@@ -199,9 +199,10 @@ async function getSeekFromWebsocketMessageContents(
 
 /**
  * Parses an ICN seek's content and runs position legality checks.
+ * Also used by the engine-game creation endpoint for its custom positions.
  * @returns `null` if the ICN is legal, or an {@link IcnSeekErrorCode} describing the failure.
  */
-function validateIcnSeekContent(content: string): IcnSeekErrorCode | null {
+export function validateIcnSeekContent(content: string): IcnSeekErrorCode | null {
 	let longFormat;
 	try {
 		longFormat = icnconverter.ShortToLong_Format(content);

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -118,3 +118,17 @@ export const gameStateLimiter = rateLimit({
 	max: 30,
 	...default_options,
 });
+
+/** Engine game creation limiter. */
+export const engineGameCreateLimiter = rateLimit({
+	windowMs: 1000 * 60, // 1 minute
+	max: 10,
+	...default_options,
+});
+
+/** Engine game state-sync limiter. Fast games sync after every move (both colors'). */
+export const engineGameSyncLimiter = rateLimit({
+	windowMs: 1000 * 60, // 1 minute
+	max: 120,
+	...default_options,
+});

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -18,6 +18,7 @@ import membersRouter from './members.js';
 import registerRouter from './register.js';
 import passwordRouter from './password.js';
 import { getGameState } from '../api/GameAPI.js';
+import engineGameRouter from './engineGame.js';
 import editorSavesRouter from './editorSaves.js';
 import preferencesRouter from './preferences.js';
 import leaderboardsRouter from './leaderboards.js';
@@ -60,6 +61,7 @@ router.post('/verify/:token', verifyPendingRegistration);
 
 router.use('/', authRouter); // login + logout (both public)
 router.use('/editor-saves', editorSavesRouter);
+router.use('/engine-game', engineGameRouter);
 router.use('/news', newsRouter);
 router.use('/preferences', preferencesRouter);
 router.use('/checkmates-progress', practiceProgressRouter);

--- a/src/server/routes/engineGame.ts
+++ b/src/server/routes/engineGame.ts
@@ -1,0 +1,24 @@
+// src/server/routes/engineGame.ts
+
+/**
+ * Router for the engine-game resource: games against an engine, played locally in the
+ * owner's browser but recorded server-side. Mounted at /api/engine-game. Every route
+ * resolves auth — guests participate too, identified by their browser id.
+ */
+
+import express from 'express';
+
+import EngineGameAPI from '../api/EngineGameAPI.js';
+import { resolveAuth } from '../middleware/resolveAuth.js';
+import { engineGameCreateLimiter, engineGameSyncLimiter, gameStateLimiter } from '../middleware/rateLimiters.js'; // prettier-ignore
+
+const router = express.Router();
+
+router.use(resolveAuth);
+
+router.post('/', engineGameCreateLimiter, EngineGameAPI.postCreateEngineGame);
+router.get('/:id', gameStateLimiter, EngineGameAPI.getEngineGameState);
+router.post('/:id/progress', engineGameSyncLimiter, EngineGameAPI.postEngineGameProgress);
+router.post('/:id/conclude', engineGameSyncLimiter, EngineGameAPI.postEngineGameConclusion);
+
+export default router;

--- a/src/server/routes/root.ts
+++ b/src/server/routes/root.ts
@@ -57,11 +57,15 @@ const variantGroups = variantregistry.getVariantGroupsWithVariants();
 page('^/$|/index(.html)?', (req: Request, res: Response) => res.render('index.njk', { variantGroups, splashText: getRandomSplashText(req) })); // prettier-ignore
 page('/about(.html)?', (_req: Request, res: Response) => res.render('about.njk'));
 page('/credits(.html)?', (_req: Request, res: Response) => res.render('credits.njk'));
-page('/game/:id', (req: Request, res: Response) => {
-	const state = getGamePageState(req);
-	if (state === undefined) return send404(req, res); // Malformed or nonexistent id
-	res.render('game.njk', state);
-});
+page(
+	'/game/:id',
+	(req: Request, res: Response) => {
+		const state = getGamePageState(req);
+		if (state === undefined) return send404(req, res); // Malformed or nonexistent id
+		res.render('game.njk', state);
+	},
+	crossOriginIsolation, // Engine games run the multi-threaded engine (SharedArrayBuffer) locally.
+);
 page(
 	'/analysis(.html)?/:id?',
 	(req: Request, res: Response) => {

--- a/src/server/views/game.njk
+++ b/src/server/views/game.njk
@@ -7,8 +7,15 @@
 {% endblock %}
 
 {% block head %}
-{# SSR→client channel: the numeric game id and a best-effort liveness hint (can be innacurate by the time they render). #}
-<script>window.gamePageData = {{ gamePageData | json | safe }};</script>
+{# SSR→client channel: the numeric game id and a best-effort liveness hint (can be innacurate by the time they render).
+   Engine games additionally get their engine's hashed worker-script URL and the content-versioned
+   engine-glue package location from the asset manifest. #}
+<script>window.gamePageData = {{ gamePageData | json | safe }};
+{%- if gamePageData.engineGame %}
+window.gamePageData.engineWorkerUrl = "{{ manifest['scripts/esm/game/chess/engines/' + gamePageData.engineGame.engine + '.ts'] }}";
+window.gamePageData.engineUrl = "{{ manifest['engine'] }}";
+{%- endif %}
+</script>
 {% endblock %}
 
 {% block body %}
@@ -197,11 +204,15 @@
 				<div class="game-actions unselectable">
 					{# Live-only actions (actions-live + the incoming draw-offer prompt) #}
 					{% if not meta.result and gamePageData.role is defined %}
-					{# Default live-game actions: offer draw + resign/abort. Visible during live play. #}
+					{# Default live-game actions: offer draw + resign/abort. Visible during live play.
+					   Engine games start it hidden too — the client reveals it once the game loads. #}
 					<div class="actions-live{{ '' if gamePageData.isLive else ' hidden' }}">
+						{# No draw offers against an engine — there's nobody to accept. #}
+						{% if not gamePageData.engineGame %}
 						<button class="action-btn tooltip-d" id="btn-offer-draw" data-tooltip="Offer draw"{% if not meta.resignable %} disabled{% endif %}>
 							<svg class="action-icon" viewBox="0 0 24 24" fill="currentColor"><text x="6" y="2" font-family="sans-serif" font-size="18" font-weight="bold" text-anchor="middle" dominant-baseline="hanging">1</text><polygon points="15.375,2 17.875,2 7.875,22 5.375,22"/><text x="18" y="21.67" font-family="sans-serif" font-size="18" font-weight="bold" text-anchor="middle" dominant-baseline="alphabetic">2</text></svg>
 						</button>
+						{% endif %}
 						{# Resign / Abort share one slot (mutually exclusive) #}
 						<button class="action-btn tooltip-d{{ '' if not meta.resignable else ' hidden'}}" id="btn-abort" data-tooltip="Abort">
 							<svg class="action-icon"><use href="#svg-x"/></svg>
@@ -211,6 +222,7 @@
 						</button>
 					</div>
 					{# Incoming draw offer #}
+					{% if not gamePageData.engineGame %}
 					<div class="actions-draw-offer hidden">
 						<span class="draw-offer-label">Accept draw offer?</span>
 						<div class="draw-offer-buttons">
@@ -220,6 +232,7 @@
 							<button class="action-btn" id="btn-reject-draw"><svg class="action-icon"><use href="#svg-x"/></svg></button>
 						</div>
 					</div>
+					{% endif %}
 					{% endif %}
 					{# Post-game actions: rematch + analysis. #}
 					<div class="actions-over{{ '' if meta.result else ' hidden' }}">
@@ -234,8 +247,9 @@
 				   is over (an opponent can't disconnect or be claimed against in a concluded game), so
 				   it won't be found on a game that loaded concluded. Starts `.hidden`: the client reveals/
 				   hides the block as the opponent drops/returns and writes the live countdown into
-				   `.disconnect-text`, then reveals `.disconnect-buttons` (also `.hidden`) on expiry. #}
-				{% if not meta.result %}
+				   `.disconnect-text`, then reveals `.disconnect-buttons` (also `.hidden`) on expiry.
+				   Omitted for engine games — the engine can't disconnect. #}
+				{% if not meta.result and not gamePageData.engineGame %}
 				<div class="disconnect-status hidden">
 					<span class="disconnect-text">Opponent disconnected. You can claim victory in 10 seconds.</span>
 					<div class="disconnect-buttons hidden">
@@ -265,8 +279,8 @@
 
 		</div>{# .play-group #}
 
-		{# Chat window — participant-only #}
-		{% if gamePageData.role is defined %}
+		{# Chat window — participant-only. Omitted for engine games (nobody to chat with). #}
+		{% if gamePageData.role is defined and not gamePageData.engineGame %}
 		<div class="chat panel">
 			{# The client toggles `.collapsed` on the .chat panel. #}
 			<div class="chat-bar">

--- a/src/shared/chess/engines/engine.ts
+++ b/src/shared/chess/engines/engine.ts
@@ -1,11 +1,11 @@
-// src/client/scripts/esm/game/chess/engines/engine.ts
+// src/shared/chess/engines/engine.ts
 
 /*
  * This module contains the centralized data structure for all engines.
  * Add a new entry to engineDictionary when adding a new engine.
  */
 
-import hydrochess_card from './enginecards/hydrochess_card.js';
+import hydrochess_card from './hydrochess_card.js';
 
 // Types ------------------------------------------------------------------------
 
@@ -49,7 +49,7 @@ export const engineDictionary = {
 		worldBorder: hydrochess_card.I64_MAX - 2000n,
 		defaultTimeLimitPerMoveMillis: 4000,
 		displayName: 'HydroChess',
-		maxStrengthLevel: 3,
+		maxStrengthLevel: 8,
 	},
 } satisfies { [key: string]: Engine };
 

--- a/src/shared/chess/engines/hydrochess_card.ts
+++ b/src/shared/chess/engines/hydrochess_card.ts
@@ -1,15 +1,11 @@
-// src/client/scripts/esm/game/chess/engines/enginecards/hydrochess_card.ts
+// src/shared/chess/engines/hydrochess_card.ts
 
-import type { VariantOptions } from '../../../../../../../shared/chess/logic/gamefile';
+import type { VariantOptions } from '../logic/gamefile.js';
 
-import bimath from '../../../../../../../shared/util/math/bimath';
-import bounds from '../../../../../../../shared/util/math/bounds';
-import coordutil from '../../../../../../../shared/chess/util/coordutil';
-import typeutil, {
-	RawType,
-	rawTypes as r,
-	players as p,
-} from '../../../../../../../shared/chess/util/typeutil';
+import bimath from '../../util/math/bimath.js';
+import bounds from '../../util/math/bounds.js';
+import coordutil from '../util/coordutil.js';
+import typeutil, { RawType, rawTypes as r, players as p } from '../util/typeutil.js';
 
 type SupportedResult = { supported: true } | { supported: false; reason: string };
 
@@ -156,6 +152,34 @@ function isPositionSupported(variantOptions: VariantOptions): SupportedResult {
 	return { supported: true };
 }
 
+/**
+ * Sets a default world border on the position for an engine game, if it doesn't have one:
+ * the pieces' bounding box padded by `worldBorderDist`, capped so no edge exceeds the
+ * engine's safe coordinate range. MUTATES the variantOptions' gameRules.
+ */
+function setDefaultWorldBorder(variantOptions: VariantOptions, worldBorderDist: bigint): void {
+	if (variantOptions.gameRules.worldBorder !== undefined) return; // Respect an explicit border.
+
+	const allCoords = [...variantOptions.position.keys()].map((coordsKey) =>
+		coordutil.getCoordsFromKey(coordsKey),
+	);
+	if (allCoords.length === 0) return; // Empty position; leave unset (illegal position anyway).
+	const bb = bounds.getBoxFromCoordsList(allCoords);
+
+	// How far can we extend in each direction before hitting the engine's coordinate cap?
+	const availableHorz = bimath.min(bb.left + BORDER_CAP, BORDER_CAP - bb.right);
+	const availableVert = bimath.min(bb.bottom + BORDER_CAP, BORDER_CAP - bb.top);
+	const distHorz = bimath.min(worldBorderDist, availableHorz);
+	const distVert = bimath.min(worldBorderDist, availableVert);
+
+	variantOptions.gameRules.worldBorder = {
+		left: bb.left - distHorz,
+		right: bb.right + distHorz,
+		bottom: bb.bottom - distVert,
+		top: bb.top + distVert,
+	};
+}
+
 export default {
 	// Constants
 	I64_MAX,
@@ -163,4 +187,5 @@ export default {
 	SUPPORTED_VARIANTS,
 	// Functions
 	isPositionSupported,
+	setDefaultWorldBorder,
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,10 +12,10 @@ import winconutil from './chess/util/winconutil.js';
 import editorutil from './util/editorutil.js';
 import gameconfig from './util/gameconfig.js';
 import typeschemas from './chess/util/typeschemas.js';
+import { players } from './chess/util/typeutil.js';
 import variantregistry from './chess/variants/variantregistry.js';
 import { POSITION_STRING_THRESHOLD } from './chess/variants/servervalidation.js';
-
-import './chess/util/typeutil.js';
+import { engineDictionary, ValidEngine } from './chess/engines/engine.js';
 
 // Common Helper Schemas ---------------------------------------------------------------
 
@@ -46,7 +46,7 @@ export const GameModeSchema = z.enum(['casual', 'rated']);
 /** The username container of an seek sent by the server. DIFFERENT FROM UsernameContainerProperties!!!! */
 export type ServerUsernameContainer = z.infer<typeof ServerUsernameContainerSchema>;
 export const ServerUsernameContainerSchema = z.strictObject({
-	type: z.enum(['player', 'guest']),
+	type: z.enum(['player', 'guest', 'engine']),
 	username: z.string(),
 	/** The rating of the user. Falls back to the INFINITY leaderboard. */
 	rating: RatingSchema.optional(),
@@ -345,3 +345,59 @@ export type OutSeek = z.infer<typeof OutSeekSchema>;
 export const OutSeekSchema = BaseSeekSchema.extend({
 	variant: OutSeekVariantSchema,
 });
+
+// Engine Game Schemas ---------------------------------------------------------------
+
+/** Hard cap on a synced engine-game moves string, in characters. */
+export const ENGINE_GAME_MOVES_STRING_CAP = 1_000_000;
+
+/** Client → server body for creating an engine (vs computer) game: `POST /api/engine-game`. */
+export type CreateEngineGameBody = z.infer<typeof CreateEngineGameBodySchema>;
+export const CreateEngineGameBodySchema = z.strictObject({
+	variant: SeekVariantSchema,
+	timeControl: TimeControlSchema,
+	/** The color the human plays. */
+	color: z.literal([players.WHITE, players.BLACK]),
+	engine: z.literal(Object.keys(engineDictionary) as ValidEngine[]),
+	/** The engine's strength level (validated against the engine's max server-side). */
+	strengthLevel: z.int().min(1),
+});
+
+/**
+ * Client → server body for syncing a live engine game's state after each move:
+ * `POST /api/engine-game/:id/progress`.
+ */
+export type EngineGameProgressBody = z.infer<typeof EngineGameProgressBodySchema>;
+export const EngineGameProgressBodySchema = z.strictObject({
+	/** Compact ICN move list with embedded clock stamps. */
+	moves: z.string().max(ENGINE_GAME_MOVES_STRING_CAP),
+	/** Ms remaining per color; absent for untimed games. */
+	clocks: typeschemas.GenPlayerGroupSchema(z.number()).optional(),
+});
+
+/** Client → server body for concluding an engine game: `POST /api/engine-game/:id/conclude`. */
+export type ConcludeEngineGameBody = z.infer<typeof ConcludeEngineGameBodySchema>;
+export const ConcludeEngineGameBodySchema = EngineGameProgressBodySchema.extend({
+	gameConclusion: winconutil.gameConclusionSchema,
+});
+
+/**
+ * The resumable state of a LIVE engine game, served over HTTP (`GET /api/engine-game/:id`)
+ * to its owner. The static setup (variant/time control/engine) is SSR'd in `gamePageData`.
+ */
+export type EngineGameState = z.infer<typeof EngineGameStateSchema>;
+export const EngineGameStateSchema = z.strictObject({
+	/** A custom game's start position ICN; absent for preset games. */
+	position: z.string().optional(),
+	/** Compact ICN move list with embedded clock stamps. */
+	moves: z.string(),
+	/** Ms remaining per color; absent for untimed games. */
+	clocks: typeschemas.GenPlayerGroupSchema(z.number()).optional(),
+});
+
+/** SSR→client channel info marking the game page's game as an engine game. */
+export interface EngineGamePageInfo {
+	engine: ValidEngine;
+	/** The engine's strength level for this game. */
+	strengthLevel: number;
+}


### PR DESCRIPTION
Implements the **Play against computer** flow. Engine games run locally in the browser via the HydroChess wasm worker (no server socket, no server-side move validation), but are recorded server-side with a real game id and persisted to the `games`/`player_games` tables on conclusion — so they get a `/game/:id` page, show up in history, and link to the analysis board exactly like PvP games.

## Server
- **`engine_games` table + manager** — one row per game, created at start, storing the human owner (`user_id`/`browser_id`), color, engine, strength, variant/position, clock, and live moves + clock snapshots. Kept after conclusion as the permanent record of the engine participant + settings.
- **`/api/engine-game` endpoints** — create, owner-only resume state, per-move progress sync, and conclude (logs to `games`/`player_games` as **casual**, no ratings/stats; a zero-move game is deleted rather than stored).
- **`gamePageController`** serves live engine games (owner-only) and resolves the engine participant + dead *guest* owners (engine games retain the browser id, unlike PvP); **`deadgamestate`** names the engine instead of falling back to "(Guest)".
- game ids are unique across `games` **and** `engine_games`; stale unconcluded engine games are purged in the periodic cleanup.

## Client
- Modal **Play against computer** creates the game and navigates to `/game/:id`. The variant dropdown **hides** engine-unsupported variants (rather than erroring on submit), and custom ICN positions are validated against the engine card (piece types, world border, piece limit, promotion lines, etc.).
- Game page loads engine games over HTTP, runs the engine locally, and syncs progress/conclusion back. Resign/abort conclude the game locally; draw-offer, chat, and disconnect UI are omitted.
- The gameplay engine now uses the **served multithreaded build** (Lazy SMP, threads = cores − 1 capped at 4), same as the analysis engine, and `/game/:id` is cross-origin isolated. Strength levels raised to **8**.

## Shared
- Engine metadata (engine dictionary + hydrochess card) moved to `src/shared/chess/engines` so both client and server use one source. The default world-border helper is extracted and shared with the board editor.

## Notes
- `enginegame` no longer imports `checkmatepractice` — the practice page registers observer hooks instead, keeping page-specific code off other pages that host engine games.
- Passes `type-check` + `lint`. Verified end-to-end over HTTP: create → owner-only SSR → resume → per-move sync → conclude → permanent record with correct result/termination + engine name on the dead/analysis pages.