### PR TITLE
Fix dev-server startup/restart race with the server build

### DIFF
--- a/build/plugins.ts
+++ b/build/plugins.ts
@@ -6,6 +6,9 @@
 
 import type { Plugin, PluginBuild } from 'esbuild';
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 /** Returns an esbuild plugin that logs whenever a build finishes/fails. */
 export function getESBuildLogStatusLogger(successMessage: string, failureMessage: string): Plugin {
 	return {
@@ -15,6 +18,26 @@ export function getESBuildLogStatusLogger(successMessage: string, failureMessage
 			build.onEnd((result) => {
 				if (result.errors.length > 0) console.error(failureMessage);
 				else console.log(successMessage);
+			});
+		},
+	};
+}
+
+/**
+ * Returns an esbuild plugin that rewrites a sentinel file after every SUCCESSFUL build.
+ * `onEnd` fires only once all output files are on disk, so dev watchers can gate on the
+ * sentinel to know a (re)build is fully complete — avoiding the race where the unbundled
+ * server starts/restarts before all its files exist. Skipped on failure, so nodemon keeps
+ * running the last good build.
+ */
+export function getBuildCompleteSentinelPlugin(sentinelPath: string): Plugin {
+	return {
+		name: 'build-complete-sentinel',
+		setup(build: PluginBuild) {
+			build.onEnd((result) => {
+				if (result.errors.length > 0) return;
+				fs.mkdirSync(path.dirname(sentinelPath), { recursive: true });
+				fs.writeFileSync(sentinelPath, String(Date.now()));
 			});
 		},
 	};

--- a/build/server.ts
+++ b/build/server.ts
@@ -3,7 +3,10 @@
 import { glob } from 'glob';
 import esbuild, { BuildOptions } from 'esbuild';
 
-import { getESBuildLogStatusLogger } from './plugins.js';
+import { getESBuildLogStatusLogger, getBuildCompleteSentinelPlugin } from './plugins.js';
+
+/** Rewritten after every successful server build; dev watchers gate on it (see plugins.ts). */
+export const SERVER_BUILD_COMPLETE_SENTINEL = 'dist/server/.build-complete';
 
 // ================================= CONSTANTS =================================
 
@@ -26,7 +29,10 @@ const esbuildOptions: BuildOptions = {
 	outdir: 'dist',
 	format: 'esm',
 	sourcemap: true, // Patches file paths from server console errors to the correct src/ file
-	plugins: [esbuildServerRebuildPlugin],
+	plugins: [
+		esbuildServerRebuildPlugin,
+		getBuildCompleteSentinelPlugin(SERVER_BUILD_COMPLETE_SENTINEL),
+	],
 };
 
 // ================================= BUILDING ===================================

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,6 @@
 {
-  "watch": ["dist/server", "dist/shared"],
-  "ext": "js",
+  "watch": ["dist/server/.build-complete"],
+  "ext": "*",
   "exec": "node --enable-source-maps dist/server/server.js",
   "delay": "200"
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "dev": "npm run clean && concurrently -k \"npm:dev:*\" --prefix-colors \"green,blue,grey,white\"",
     "dev:build": "npm run generate:types && tsx build/index.ts --dev",
     "dev:tsc": "tsc -b --noEmit --watch --preserveWatchOutput",
-    "dev:server": "wait-on dist/server/server.js && nodemon",
+    "dev:server": "wait-on dist/server/.build-complete dist/manifest.json && nodemon",
     "dev:assets": "cpx \"src/**/*.{png,jpg,webp,avif,svg,ico,gif,mp3,wav,opus,glsl,md,woff2,woff,njk}\" dist --watch",
     "generate:types": "tsx scripts/generate-translation-types.ts && tsx scripts/generate-component-translation-types.ts",
     "optimize-images": "tsx scripts/optimize-images.ts",


### PR DESCRIPTION
## Summary
- The unbundled server build (esbuild, `bundle: false`) writes each output file individually, so `wait-on dist/server/server.js` (and nodemon's directory watch on rebuild) could fire before all of a build's files existed — crashing the server with `ERR_MODULE_NOT_FOUND` on startup or restart.
- The client build's `dist/manifest.json` (read eagerly by Nunjucks at server startup) could also still be missing at that point, causing a separate crash.
- Adds a build-complete sentinel file (`dist/server/.build-complete`), rewritten only in esbuild's `onEnd` on a successful build (which only fires once every output file is on disk), and gates both the initial `wait-on` and nodemon's restart watch on that sentinel plus the manifest.

## Test plan
- [x] `npm run type-check` — no new errors introduced (pre-existing unrelated errors confirmed present without this change too)
- [x] `npm run lint` — clean on all touched files
- [x] Ran `npm run dev` from a clean `dist/` — server now starts only after both the server build and client manifest are fully written, no crash