### PR TITLE
Add max-ply adjudication to allowed conditions in icnvalidator

### DIFF
--- a/src/client/scripts/esm/workers/icnvalidator.worker.ts
+++ b/src/client/scripts/esm/workers/icnvalidator.worker.ts
@@ -166,11 +166,21 @@ function validateTermination(
 			);
 		return;
 	}
-	if (termination && termination.startsWith('Material adjudication')) {
-		if (gameConclusion !== undefined)
+	// Check for adjudication terminations
+	if (
+		termination &&
+		(termination.startsWith('Material adjudication') ||
+			termination.startsWith('adjudication') ||
+			termination.startsWith('Max-ply adjudication'))
+	) {
+		if (gameConclusion !== undefined) {
+			// Max-ply adjudication is reported as "adjudication" in the metadata, so we rename it for specificity
+			if (termination.startsWith('adjudication')) termination = 'Max-ply adjudication';
+
 			throw new Error(
-				`Termination is Material Adjudication, but game is over: ${JSON.stringify(gameConclusion)}`,
+				`Termination is ${termination}, but game is over: ${JSON.stringify(gameConclusion)}`,
 			);
+		}
 		return;
 	}
 	if (gameConclusion === undefined) {

--- a/src/client/scripts/esm/workers/icnvalidator.worker.ts
+++ b/src/client/scripts/esm/workers/icnvalidator.worker.ts
@@ -166,21 +166,16 @@ function validateTermination(
 			);
 		return;
 	}
-	// Check for adjudication terminations
+	// Adjudication terminations are suffixed with their eval threshold, e.g. "Max-ply adjudication (|eval| >= 1000 cp)"
 	if (
 		termination &&
 		(termination.startsWith('Material adjudication') ||
-			termination.startsWith('adjudication') ||
 			termination.startsWith('Max-ply adjudication'))
 	) {
-		if (gameConclusion !== undefined) {
-			// Max-ply adjudication is reported as "adjudication" in the metadata, so we rename it for specificity
-			if (termination.startsWith('adjudication')) termination = 'Max-ply adjudication';
-
+		if (gameConclusion !== undefined)
 			throw new Error(
-				`Termination is ${termination}, but game is over: ${JSON.stringify(gameConclusion)}`,
+				`Termination is "${termination}", but game is over: ${JSON.stringify(gameConclusion)}`,
 			);
-		}
 		return;
 	}
 	if (gameConclusion === undefined) {


### PR DESCRIPTION
### Summary
Fixes most termination mismatches (~20% of games) since max-ply adjudication was added.

### Results
9100 games (`base_only` variants) tested
| | Games Passed | Success rate | Termination mismatches |
|--------|--------|--------|--------|
| Before | 7398 / 9100 | 81.3% | 1702 |
| **After** | **9084 / 9100** | **99.8%** | **16** |