### PR TITLE
Hold user-triggered socket messages across a disconnect

### DIFF
--- a/src/client/scripts/esm/game/chess/gameslot.ts
+++ b/src/client/scripts/esm/game/chess/gameslot.ts
@@ -20,6 +20,7 @@ import movepiece from '../../../../../shared/chess/logic/movepiece.js';
 import boardutil from '../../../../../shared/chess/util/boardutil.js';
 import gamerules from '../../../../../shared/chess/util/gamerules.js';
 import variantcache from '../../../../../shared/chess/variants/variantcache.js';
+import gamefileutility from '../../../../../shared/chess/util/gamefileutility.js';
 import typeutil, { players as p } from '../../../../../shared/chess/util/typeutil.js';
 
 import arrows from '../rendering/arrows/arrows.js';
@@ -105,6 +106,11 @@ function getMesh(): Mesh | undefined {
 
 function areInGame(): boolean {
 	return loadedGamefile !== undefined;
+}
+
+/** Whether a game is loaded and hasn't concluded yet. */
+function isGameLive(): boolean {
+	return loadedGamefile !== undefined && !gamefileutility.isGameOver(loadedGamefile);
 }
 
 function areViewingWhite(): boolean {
@@ -268,6 +274,7 @@ export default {
 	getGamefile,
 	getMesh,
 	areInGame,
+	isGameLive,
 	areViewingWhite,
 	flipView,
 	loadGamefile,

--- a/src/client/scripts/esm/game/chess/gameslot.ts
+++ b/src/client/scripts/esm/game/chess/gameslot.ts
@@ -108,7 +108,7 @@ function areInGame(): boolean {
 	return loadedGamefile !== undefined;
 }
 
-/** Whether a game is loaded and hasn't concluded yet. */
+/** Whether a game is loaded and hasn't concluded (locally) yet. */
 function isGameLive(): boolean {
 	return loadedGamefile !== undefined && !gamefileutility.isGameOver(loadedGamefile);
 }

--- a/src/client/scripts/esm/game/gui/guidisconnect.ts
+++ b/src/client/scripts/esm/game/gui/guidisconnect.ts
@@ -19,7 +19,7 @@ import moveutil from '../../../../../shared/chess/util/moveutil.js';
 
 import gameslot from '../chess/gameslot.js';
 import { GameBus } from '../GameBus.js';
-import socketmessages from '../../websocket/socketmessages.js';
+import socketintents from '../../websocket/socketintents.js';
 
 // Elements ----------------------------------------------------------------------------------
 
@@ -96,14 +96,25 @@ function render(): void {
 
 // Button handlers ----------------------------------------------------------------------------
 
+/**
+ * Whether the claim window is currently open. A resync restores the opponent's disconnect
+ * state from the server, so a held claim is dropped once they're back.
+ */
+function isClaimable(): boolean {
+	// Load-bearing: claimableAt is only cleared on 'game-concluded', which online games don't
+	// dispatch off our own locally-detected conclusion — so it outlives the game briefly.
+	if (!gameslot.isGameLive()) return false;
+	return claimableAt !== undefined && Date.now() >= claimableAt;
+}
+
 /** Claims victory against the disconnected opponent. Server validates the window is open. */
 function callback_ClaimVictory(): void {
-	socketmessages.send('game', 'claimvictory');
+	socketintents.submit('game', 'claimvictory', undefined, isClaimable);
 }
 
 /** Claims a draw against the disconnected opponent. Server validates the window is open. */
 function callback_ClaimDraw(): void {
-	socketmessages.send('game', 'claimdraw');
+	socketintents.submit('game', 'claimdraw', undefined, isClaimable);
 }
 
 element_ClaimVictory?.addEventListener('click', callback_ClaimVictory);

--- a/src/client/scripts/esm/game/gui/guigameactions.ts
+++ b/src/client/scripts/esm/game/gui/guigameactions.ts
@@ -29,7 +29,7 @@ import drawoffers from '../misc/onlinegame/drawoffers.js';
 import onlinegame from '../misc/onlinegame/onlinegame.js';
 import { GameBus } from '../GameBus.js';
 import { SocketBus } from '../../websocket/SocketBus.js';
-import socketmessages from '../../websocket/socketmessages.js';
+import socketintents from '../../websocket/socketintents.js';
 
 // Elements ----------------------------------------------------------------------------------
 
@@ -199,7 +199,7 @@ function callback_OfferDraw(): void {
 
 /** Resigns the game. Server only accepts if the game is resignable (2+ plies). */
 function callback_Resign(): void {
-	socketmessages.send('game', 'resign');
+	socketintents.submit('game', 'resign', undefined, () => gameslot.isGameLive());
 }
 
 /**
@@ -209,7 +209,13 @@ function callback_Resign(): void {
  * but the abort button hadn't yet swapped out for resign.
  */
 function callback_Abort(): void {
-	socketmessages.send('game', 'abort');
+	// Held across a disconnect only while the game is still in abort territory —
+	// the same condition that decides which of the two buttons is showing.
+	socketintents.submit('game', 'abort', undefined, () => {
+		const gamefile = gameslot.getGamefile();
+		if (gamefile === undefined || gamefileutility.isGameOver(gamefile)) return false;
+		return !moveutil.isGameResignable(gamefile);
+	});
 }
 
 /** Navigates to the post-game analysis board. */
@@ -236,8 +242,15 @@ function updateRematchButton(): void {
 	if (!element_Rematch) return; // Absent (spectator, or game loaded dead).
 	element_Rematch.classList.toggle('rematch-offered', opponentOfferedRematch && !weOfferedRematch); // prettier-ignore
 	if (graceTimers.has(element_ActionsOver)) return; // Mid-appearance grace — leave disabled state to it.
-	element_Rematch.disabled =
-		weOfferedRematch || !opponentPresentPostGame || !onlinegame.areInSync();
+	element_Rematch.disabled = !canOfferRematch() || !onlinegame.areInSync();
+}
+
+/**
+ * Whether extending a rematch offer currently makes sense. A resync resets
+ * {@link weOfferedRematch}, since the server doesn't report our own outstanding offer back.
+ */
+function canOfferRematch(): boolean {
+	return !weOfferedRematch && opponentPresentPostGame;
 }
 
 /**
@@ -255,7 +268,7 @@ function setRematchState(rematch: RematchOfferInfo): void {
 /** Extends a rematch offer to our opponent. Clicking while they're offering accepts theirs. */
 function callback_Rematch(): void {
 	if (weOfferedRematch) return; // Already offered.
-	socketmessages.send('game', 'offerrematch');
+	socketintents.submit('game', 'offerrematch', undefined, () => canOfferRematch());
 	weOfferedRematch = true;
 	updateRematchButton();
 }

--- a/src/client/scripts/esm/game/misc/enginegame.ts
+++ b/src/client/scripts/esm/game/misc/enginegame.ts
@@ -26,8 +26,8 @@ import selection from '../chess/selection.js';
 import { GameBus } from '../GameBus.js';
 import gamesession from '../chess/gamesession.js';
 import movesequence from '../chess/movesequence.js';
+import socketintents from '../../websocket/socketintents.js';
 import gamecompressor from '../chess/gamecompressor.js';
-import socketmessages from '../../websocket/socketmessages.js';
 import enginelegalmovesdebug from './enginelegalmovesdebug.js';
 import { maxEngineThreads, THREAD_CAP } from '../chess/engines/enginewasm.js';
 
@@ -254,7 +254,7 @@ function makeEngineMove(tokenMove: string | null): void {
 
 /** Asks the server to resign the engine in the current online game. */
 function resignFailedEngine(): void {
-	socketmessages.send('game', 'engineresign', undefined, true);
+	socketintents.submit('game', 'engineresign', undefined, () => gameslot.isGameLive());
 }
 
 /** Requests engine-generated legal moves for the currently viewed position. */

--- a/src/client/scripts/esm/game/misc/onlinegame/drawoffers.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/drawoffers.ts
@@ -114,8 +114,8 @@ function extendOffer(): void {
  */
 function callback_AcceptDraw(): void {
 	isAcceptingDraw = false;
-	// A resync restores isAcceptingDraw from the server, so a held intent is dropped
-	// if the offer is no longer open by the time we're back.
+	// A resync restores isAcceptingDraw from the server, so a held intent
+	// is dropped if the offer is no longer open by the time we're back.
 	socketintents.submit('game', 'acceptdraw', undefined, () => gameslot.isGameLive() && isAcceptingDraw); // prettier-ignore
 	gameactions.refresh();
 }

--- a/src/client/scripts/esm/game/misc/onlinegame/drawoffers.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/drawoffers.ts
@@ -17,7 +17,7 @@ import gameslot from '../../chess/gameslot.js';
 import gamesound from '../gamesound.js';
 import gameactions from '../../gui/guigameactions.js';
 import { GameBus } from '../../GameBus.js';
-import socketmessages from '../../../websocket/socketmessages.js';
+import socketintents from '../../../websocket/socketintents.js';
 
 // Variables ---------------------------------------------------
 
@@ -54,6 +54,7 @@ GameBus.addEventListener('user-move-played', () => closeDraw());
 function isOfferingDrawLegal(): boolean {
 	const gamefile = gameslot.getGamefile();
 	if (!gamefile) return false; // Game not loaded yet
+	if (!gameslot.isGameLive()) return false; // Already concluded
 	if (!moveutil.isGameResignable(gamefile)) return false; // Not at least 2+ moves
 	if (isTooSoonToOfferDraw()) return false; // It's been too soon since our last offer
 	return true; // Is legal to EXTEND
@@ -97,7 +98,9 @@ function onOpponentDeclinedOffer(): void {
  * All legality checks have already passed!
  */
 function extendOffer(): void {
-	socketmessages.send('game', 'offerdraw');
+	// A resync restores plyOfLastOfferedDraw from the server, so if our offer never landed
+	// this reads as "we haven't offered" and the held intent is still legal to send.
+	socketintents.submit('game', 'offerdraw', undefined, () => isOfferingDrawLegal());
 	const gamefile = gameslot.getGamefile()!;
 	plyOfLastOfferedDraw = gamefile.moves.length;
 	gameactions.updateOfferDrawButton(); // It's now too soon to offer again — disable the button.
@@ -111,7 +114,9 @@ function extendOffer(): void {
  */
 function callback_AcceptDraw(): void {
 	isAcceptingDraw = false;
-	socketmessages.send('game', 'acceptdraw');
+	// A resync restores isAcceptingDraw from the server, so a held intent is dropped
+	// if the offer is no longer open by the time we're back.
+	socketintents.submit('game', 'acceptdraw', undefined, () => gameslot.isGameLive() && isAcceptingDraw); // prettier-ignore
 	gameactions.refresh();
 }
 
@@ -127,7 +132,7 @@ function callback_declineDraw(): void {
 	if (!isAcceptingDraw) return; // No open draw offer from our opponent
 	closeDraw();
 	// Notify the server
-	socketmessages.send('game', 'declinedraw');
+	socketintents.submit('game', 'declinedraw', undefined, () => gameslot.isGameLive() && isAcceptingDraw); // prettier-ignore
 	// TODO: Log into chat window instead.
 	toast.show(`Draw declined`);
 }

--- a/src/client/scripts/esm/game/misc/onlinegame/movesendreceive.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/movesendreceive.ts
@@ -55,7 +55,7 @@ function submitMove(gamefile: GameFile, moveIndex: number): void {
 		gameConclusion: isLastMove ? gamefile.gameConclusion : undefined,
 	};
 
-	socketmessages.send('game', 'submitmove', data, true);
+	void socketmessages.send('game', 'submitmove', data);
 }
 
 /**
@@ -155,7 +155,7 @@ function reportOpponentsMove(reason: string): void {
 	// Send the move number of the opponents move so that there's no mixup of which move we claim is illegal.
 	const opponentsMoveNumber = gameslot.getGamefile()!.moves.length + 1;
 	const message = { reason, opponentsMoveNumber };
-	socketmessages.send('game', 'report', message);
+	void socketmessages.send('game', 'report', message);
 }
 
 /**

--- a/src/client/scripts/esm/game/misc/onlinegame/onlinegame.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/onlinegame.ts
@@ -8,7 +8,6 @@ import type { Additional } from '../../../../../../shared/chess/logic/gamefile.j
 import type { GameStateMessage, ParticipantState } from '../../../../../../shared/types.js';
 
 import apeiron_card from '../../../../../../shared/chess/engines/apeiron_card.js';
-import gamefileutility from '../../../../../../shared/chess/util/gamefileutility.js';
 import { players as p } from '../../../../../../shared/chess/util/typeutil.js';
 import { engineDictionary } from '../../../../../../shared/chess/engine.js';
 
@@ -192,7 +191,7 @@ function setParticipantState(participantState?: ParticipantState): void {
 function confirmNavigationAwayFromGame(event: MouseEvent): void {
 	// Check if Command (Meta) or Ctrl key is held down
 	if (event.metaKey || event.ctrlKey) return; // Allow opening in a new tab without confirmation
-	if (gamefileutility.isGameOver(gameslot.getGamefile()!)) return;
+	if (!gameslot.isGameLive()) return;
 	if (gamesession.getRole() === undefined) return; // Spectator
 
 	const userConfirmed = confirm('Are you sure you want to leave the game?');

--- a/src/client/scripts/esm/game/misc/onlinegame/onlinegame.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/onlinegame.ts
@@ -221,11 +221,11 @@ function subscribeToGame(): void {
 	socketsubs.addSub('game'); // subs were cleared when the socket closed.
 	if (stage === 'finalized' && gameslot.getGamefile()) {
 		// The result is locked in — nothing but rematch offers can change, so we can't desync.
-		socketmessages.send('game', 'subscriberematch', id);
+		void socketmessages.send('game', 'subscriberematch', id);
 	} else {
 		// No game loaded yet (initial subscribe), a load that failed and left us with none,
 		// or it's live but not finalized (may still change) — request the full state.
-		socketmessages.send('game', 'subscribe', id);
+		void socketmessages.send('game', 'subscribe', id);
 	}
 }
 

--- a/src/client/scripts/esm/game/misc/onlinegame/onlinegamerouter.ts
+++ b/src/client/scripts/esm/game/misc/onlinegame/onlinegamerouter.ts
@@ -21,6 +21,7 @@ import pingManager from '../../../util/pingManager.js';
 import guigamemeta from '../../gui/guigamemeta.js';
 import guidisconnect from '../../gui/guidisconnect.js';
 import { SocketBus } from '../../../websocket/SocketBus.js';
+import socketintents from '../../../websocket/socketintents.js';
 import guigameactions from '../../gui/guigameactions.js';
 import movesendreceive from './movesendreceive.js';
 
@@ -65,6 +66,7 @@ function receiveMessage(contents: GameMessage): void {
 			onlinegame.setInSync(true); // We're in sync whenever we receive a gamestate/rematchstate message.
 			// Nothing loaded/loading yet: the first `gamestate` bootstraps the game.
 			onlinegame.loadGameFromState(contents.value, false);
+			socketintents.onRouteSynced('game');
 		} else {
 			console.error(`Received game message before receiving gamestate: ${JSON.stringify(contents)}`); // prettier-ignore
 		}
@@ -86,6 +88,9 @@ function routeMessage(contents: GameMessage): void {
 		case 'gamestate':
 			onlinegame.setInSync(true); // We're in sync whenever we receive a gamestate/rematchstate message.
 			resyncer.handleGameState(gamefile, mesh, contents.value);
+			// AFTER the resync, not alongside setInSync() above: the intents held through the
+			// outage check the reconciled board to decide whether they still make sense.
+			socketintents.onRouteSynced('game');
 			break;
 		case 'move':
 			movesendreceive.handleMove(gamefile, mesh, contents.value);
@@ -120,6 +125,7 @@ function routeMessage(contents: GameMessage): void {
 		case 'rematchstate':
 			onlinegame.setInSync(true); // We're in sync whenever we receive a gamestate/rematchstate message.
 			gameactions.setRematchState(contents.value);
+			socketintents.onRouteSynced('game');
 			break;
 		case 'rematchoffer':
 			gameactions.onOpponentRematchOffer();

--- a/src/client/scripts/esm/views/index/index.ts
+++ b/src/client/scripts/esm/views/index/index.ts
@@ -29,13 +29,8 @@ SocketBus.addEventListener('lobby', (e) => onLobbyMessage(e.detail));
 
 function onLobbyMessage(contents: LobbyMessage): void {
 	switch (contents.action) {
-		case 'lobbysnapshot':
-			// In-game status first: the seek intents released below check it.
-			if (contents.value.ingame)
-				void lobby.onInGame(contents.value.ingame.id, contents.value.ingame.navigate);
-			else lobby.onOutGame();
-			lobby.onSeekListUpdate(contents.value.seekslist);
-			lobby.onViewerCountUpdate(contents.value.viewercount);
+		case 'lobbystate':
+			lobby.handleLobbyState(contents.value);
 			// The full lobby state is now applied — release any intents held through the outage.
 			socketintents.onRouteSynced('lobby');
 			break;

--- a/src/client/scripts/esm/views/index/index.ts
+++ b/src/client/scripts/esm/views/index/index.ts
@@ -10,6 +10,7 @@ import type { LobbyMessage } from '../../websocket/socketschemas.js';
 
 import lobby from './lobby.js';
 import flashToast from '../../util/flashToast.js';
+import socketintents from '../../websocket/socketintents.js';
 import { SocketBus } from '../../websocket/SocketBus.js';
 
 import './newPrompt.js';
@@ -29,8 +30,14 @@ SocketBus.addEventListener('lobby', (e) => onLobbyMessage(e.detail));
 function onLobbyMessage(contents: LobbyMessage): void {
 	switch (contents.action) {
 		case 'lobbysnapshot':
+			// In-game status first: the seek intents released below check it.
+			if (contents.value.ingame)
+				void lobby.onInGame(contents.value.ingame.id, contents.value.ingame.navigate);
+			else lobby.onOutGame();
 			lobby.onSeekListUpdate(contents.value.seekslist);
 			lobby.onViewerCountUpdate(contents.value.viewercount);
+			// The full lobby state is now applied — release any intents held through the outage.
+			socketintents.onRouteSynced('lobby');
 			break;
 		case 'seekslist':
 			lobby.onSeekListUpdate(contents.value.seeksList);

--- a/src/client/scripts/esm/views/index/lobby.ts
+++ b/src/client/scripts/esm/views/index/lobby.ts
@@ -30,6 +30,7 @@ import gamesound from '../../game/misc/gamesound.js';
 import socketsubs from '../../websocket/socketsubs.js';
 import LocalStorage from '../../util/LocalStorage.js';
 import validatorama from '../../util/validatorama.js';
+import socketintents from '../../websocket/socketintents.js';
 import socketmessages from '../../websocket/socketmessages.js';
 import gameSetupModal from './gameSetupModal.js';
 import seekPreviewCache from './seekPreviewCache.js';
@@ -86,8 +87,11 @@ const rowVacatedTimes: number[] = [];
 
 /** Whether the user is currently idle (lobby unsubbed, overlay visible). */
 let isIdle = false;
-/** Whether the in-a-game banner is currently shown (set by the server's 'ingame'/'outgame' pushes). */
-let inGameBannerShown = false;
+/**
+ * The id of the game the server says we're in, if any. Set by the lobby snapshot and the
+ * live 'ingame'/'outgame' pushes. Seeks are pointless while we're in a game.
+ */
+let gameIdWeAreIn: number | undefined;
 
 // Init -----------------------------------------------
 
@@ -239,6 +243,7 @@ function onViewerCountUpdate(count: number): void {
  * or it started while we were away and this is our first chance to be told.
  */
 async function onInGame(id: number, navigate: boolean): Promise<void> {
+	gameIdWeAreIn = id;
 	if (navigate) {
 		// Plays the notify sound and awaits it so the hard-navigate doesn't cut it off.
 		// No reverb added here, it makes us wait too long.
@@ -252,14 +257,14 @@ async function onInGame(id: number, navigate: boolean): Promise<void> {
 	}
 }
 
-/** Called on the server's 'outgame' push — we've left our game, so hide the banner. */
+/** Called when the server reports we're in no game — its 'outgame' push, or a snapshot without one. */
 function onOutGame(): void {
+	gameIdWeAreIn = undefined;
 	hideInGameBanner();
 }
 
 /** Shows the "you're in a game" banner, pointing its rejoin link at game `id`. */
 function showInGameBanner(id: number): void {
-	inGameBannerShown = true;
 	element_lobbyIngameJoin.setAttribute('href', `/game/${uuid.base10ToBase62(id)}`);
 	element_lobbyIngameOverlay.classList.remove('hidden');
 	for (const btn of elements_disabledWhileInGame) btn.setAttribute('disabled', '');
@@ -268,8 +273,6 @@ function showInGameBanner(id: number): void {
 
 /** Hides the in-game banner. */
 function hideInGameBanner(): void {
-	if (!inGameBannerShown) return;
-	inGameBannerShown = false;
 	element_lobbyIngameOverlay.classList.add('hidden');
 	for (const btn of elements_disabledWhileInGame) btn.removeAttribute('disabled');
 }
@@ -297,7 +300,7 @@ function outSeekToLobbySeek(seek: OutSeek): LobbySeek {
 /** Sends a createseek message to the server with the given options. */
 function createSeek(options: CreateSeekOptions): void {
 	const tag = generateTag();
-	socketmessages.send('lobby', 'createseek', { ...options, tag }, true);
+	socketintents.submit('lobby', 'createseek', { ...options, tag }, () => gameIdWeAreIn === undefined); // prettier-ignore
 }
 
 /**
@@ -305,19 +308,21 @@ function createSeek(options: CreateSeekOptions): void {
  * socket is required, gating bots. Navigation happens on the server's `ingame` push.
  */
 function createEngineGame(body: CreateEngineGameMessage): void {
-	socketmessages.send('lobby', 'createengine', body, true);
+	socketintents.submit('lobby', 'createengine', body, () => gameIdWeAreIn === undefined);
 }
 
 /** Sends a cancelseek message for our current seek. */
 function cancel(seekId: string): void {
 	if (ourSeekId === undefined) return;
 	LocalStorage.deleteItem('invite-tag');
-	socketmessages.send('lobby', 'cancelseek', seekId, true);
+	// Nothing to cancel if the seek is gone by the time we're back in sync. Checked by
+	// presence, not ownership — the tag deleted above is what ownership is derived from.
+	socketintents.submit('lobby', 'cancelseek', seekId, () => seekMap.has(seekId));
 }
 
 /** Sends an acceptseek message for an opponent's seek. */
 function accept(seekId: string): void {
-	socketmessages.send('lobby', 'acceptseek', seekId, true);
+	socketintents.submit('lobby', 'acceptseek', seekId, () => gameIdWeAreIn === undefined && seekMap.has(seekId)); // prettier-ignore
 }
 
 // Subscribing ---------------------------------------------
@@ -327,7 +332,7 @@ async function subscribe(): Promise<void> {
 	if (isIdle) return; // Don't resubscribe while idle; the user must interact with the lobby to reconnect
 	if (socketsubs.areSubbedToSub('lobby')) return;
 	socketsubs.addSub('lobby');
-	socketmessages.send('general', 'sub', 'lobby');
+	void socketmessages.send('general', 'sub', 'lobby');
 }
 
 /** Unsubscribes from the invites list and clears the rendered seek list. */

--- a/src/client/scripts/esm/views/index/lobby.ts
+++ b/src/client/scripts/esm/views/index/lobby.ts
@@ -12,6 +12,7 @@ import type {
 	BaseSeek,
 	OutSeek,
 	CreateSeekOptions,
+	LobbyStateMessage,
 	CreateEngineGameMessage,
 } from '../../../../../shared/types.js';
 
@@ -88,8 +89,8 @@ const rowVacatedTimes: number[] = [];
 /** Whether the user is currently idle (lobby unsubbed, overlay visible). */
 let isIdle = false;
 /**
- * The id of the game the server says we're in, if any. Set by the lobby snapshot and the
- * live 'ingame'/'outgame' pushes. Seeks are pointless while we're in a game.
+ * The id of the game the server says we're in, if any. Set by the lobby state and
+ * the live 'ingame'/'outgame' pushes. Seeks are pointless while we're in a game.
  */
 let gameIdWeAreIn: number | undefined;
 
@@ -137,6 +138,15 @@ function isSeekOurs(seek: OutSeek): boolean {
 	}
 	const localTag = LocalStorage.loadItem('invite-tag');
 	return seek.tag === localTag;
+}
+
+/** Applies the full lobby snapshot received the moment we (re)subscribe. */
+function handleLobbyState(state: LobbyStateMessage): void {
+	// In-game status first: the seek intents released after this check it.
+	if (state.ingame) void onInGame(state.ingame.id, state.ingame.navigate);
+	else onOutGame();
+	onSeekListUpdate(state.seekslist);
+	onViewerCountUpdate(state.viewercount);
 }
 
 /**
@@ -566,6 +576,7 @@ function createSideDotVNode(color: LobbySeek['color']): VNode | null {
 export default {
 	renderSeekList,
 	clearSeekList,
+	handleLobbyState,
 	onSeekListUpdate,
 	onViewerCountUpdate,
 	onInGame,

--- a/src/client/scripts/esm/websocket/socketintents.ts
+++ b/src/client/scripts/esm/websocket/socketintents.ts
@@ -1,0 +1,117 @@
+// src/client/scripts/esm/websocket/socketintents.ts
+
+/**
+ * Delivery layer for user-triggered socket messages ("intents").
+ *
+ * An intent must survive a disconnect — a click shouldn't vanish because the socket happened
+ * to be down — but it must not be replayed blindly either, since by the time we reconnect the
+ * state it was meant for may have moved on (the game ended, someone else took our seek). So an
+ * intent that can't go out right now is held, and re-checked against the server's authoritative
+ * state the moment its route resyncs.
+ *
+ * Protocol traffic (echoes, sub/unsub, resubscribing, move submission) bypasses this and uses
+ * socketmessages.send() directly — deferring the messages the resync itself depends on would
+ * deadlock, and moves have their own reconciliation in resyncer.
+ */
+
+import type { Sub } from './socketsubs.js';
+
+import socketman from './socketman.js';
+import { SocketBus } from './SocketBus.js';
+import socketmessages from './socketmessages.js';
+
+// Types -----------------------------------------------------------------------
+
+/** A user-triggered message held until its route can accept it. */
+type Intent = {
+	action: string;
+	value: unknown;
+	isStillValid: () => boolean;
+	/** Epoch ms past which the user has mentally moved on, and we silently drop it. */
+	expiresAt: number;
+};
+
+// Constants -------------------------------------------------------------------
+
+/**
+ * How long a held intent stays eligible to send. Past this the user has long since assumed
+ * their click didn't register, and would be surprised to see it take effect. A backstop only —
+ * correctness comes from each intent's validity check, not from this.
+ */
+const INTENT_LIFETIME_MILLIS = 10000;
+
+// Variables -------------------------------------------------------------------
+
+/** Intents held per route, in submission order. Only ever non-empty while that route is out of sync. */
+const held: Record<Sub, Intent[]> = { lobby: [], game: [] };
+
+/**
+ * Which routes we currently hold the server's authoritative state for.
+ * Being subscribed isn't enough — an intent's validity check reads that state.
+ */
+const synced: Record<Sub, boolean> = { lobby: false, game: false };
+
+// Events ----------------------------------------------------------------------
+
+// Whatever state we held is stale the moment the connection drops. Held intents
+// deliberately survive this — they're what the next resync re-evaluates.
+SocketBus.addEventListener('closed', () => {
+	for (const route of Object.keys(synced) as Sub[]) synced[route] = false;
+});
+
+// Functions -------------------------------------------------------------------
+
+/**
+ * Sends a user-triggered message, or holds it until its route is back in sync.
+ * @param isStillValid - Re-checked against the server's state before a held intent goes out.
+ * Return false once the action no longer makes sense and it's dropped instead.
+ */
+function submit(route: Sub, action: string, value: unknown, isStillValid: () => boolean): void {
+	if (isRouteReady(route)) {
+		void socketmessages.send(route, action, value);
+		return;
+	}
+	held[route].push({
+		action,
+		value,
+		isStillValid,
+		expiresAt: Date.now() + INTENT_LIFETIME_MILLIS,
+	});
+}
+
+/**
+ * Marks a route as holding the server's authoritative state, and sends the intents held for
+ * it that are still worth sending.
+ *
+ * MUST be called only once that state has been APPLIED, not merely received — the validity
+ * checks read it. That's why this is separate from onlinegame's `inSync` flag, which has to
+ * be set beforehand so resyncer can submit moves as it reconciles the board.
+ */
+function onRouteSynced(route: Sub): void {
+	synced[route] = true;
+
+	const intents = held[route];
+	if (intents.length === 0) return;
+	held[route] = [];
+
+	const now = Date.now();
+	for (const intent of intents) {
+		if (now > intent.expiresAt) continue;
+		if (!intent.isStillValid()) continue;
+		void socketmessages.send(route, intent.action, intent.value);
+	}
+}
+
+/** Whether a route can take a message right now: an open socket, and its state in hand. */
+function isRouteReady(route: Sub): boolean {
+	if (!synced[route]) return false;
+	const socket = socketman.getSocket();
+	return socket !== undefined && socket.readyState === WebSocket.OPEN;
+}
+
+// Exports ---------------------------------------------------------------------
+
+export default {
+	submit,
+	onRouteSynced,
+};

--- a/src/client/scripts/esm/websocket/socketintents.ts
+++ b/src/client/scripts/esm/websocket/socketintents.ts
@@ -34,9 +34,9 @@ type Intent = {
 // Constants -------------------------------------------------------------------
 
 /**
- * How long a held intent stays eligible to send. Past this the user has long since assumed
- * their click didn't register, and would be surprised to see it take effect. A backstop only —
- * correctness comes from each intent's validity check, not from this.
+ * How long a held intent stays eligible to send. Past this the user has long since
+ * assumed their click didn't register, and would be surprised to see it take effect.
+ * A backstop only — correctness comes from each intent's validity check, not from this.
  */
 const INTENT_LIFETIME_MILLIS = 10000;
 
@@ -71,12 +71,22 @@ function submit(route: Sub, action: string, value: unknown, isStillValid: () => 
 		void socketmessages.send(route, action, value);
 		return;
 	}
+	// Not ready: hold it until the route resyncs, or until the user has moved on.
 	held[route].push({
 		action,
 		value,
 		isStillValid,
 		expiresAt: Date.now() + INTENT_LIFETIME_MILLIS,
 	});
+}
+
+/** Whether a route can take a message right now: an open socket, and its state in hand. */
+function isRouteReady(route: Sub): boolean {
+	if (!synced[route]) return false;
+	// Not redundant with the sync flag: a client-initiated close() leaves the socket CLOSING
+	// for a while, and `closed` (which clears the flag) only fires once it's actually shut.
+	const socket = socketman.getSocket();
+	return socket !== undefined && socket.readyState === WebSocket.OPEN;
 }
 
 /**
@@ -96,17 +106,10 @@ function onRouteSynced(route: Sub): void {
 
 	const now = Date.now();
 	for (const intent of intents) {
-		if (now > intent.expiresAt) continue;
-		if (!intent.isStillValid()) continue;
+		if (now > intent.expiresAt) continue; // User has moved on.
+		if (!intent.isStillValid()) continue; // No longer makes sense.
 		void socketmessages.send(route, intent.action, intent.value);
 	}
-}
-
-/** Whether a route can take a message right now: an open socket, and its state in hand. */
-function isRouteReady(route: Sub): boolean {
-	if (!synced[route]) return false;
-	const socket = socketman.getSocket();
-	return socket !== undefined && socket.readyState === WebSocket.OPEN;
 }
 
 // Exports ---------------------------------------------------------------------

--- a/src/client/scripts/esm/websocket/socketmessages.ts
+++ b/src/client/scripts/esm/websocket/socketmessages.ts
@@ -1,7 +1,10 @@
 // src/client/scripts/esm/websocket/socketmessages.ts
 
 /**
- * Handles outgoing websocket messages, echo tracking, and on-reply functions.
+ * Handles outgoing websocket messages and echo tracking.
+ *
+ * This is the raw transport. User-triggered messages go through socketintents instead,
+ * which holds them across a disconnect rather than letting them fall on the floor.
  */
 
 import uuid from '../../../../shared/util/uuid.js';
@@ -40,9 +43,6 @@ const alsoPrintIncomingEchos = false;
 
 /** Echo timers for sent messages awaiting acknowledgement. */
 let echoTimers: Record<string, { timeSent: number; timeoutID: number }> = {};
-
-/** Functions to execute when we get a specific reply back. */
-let onreplyFuncs: { [key: MessageID]: Function } = {};
 
 /** The timeout ID that auto-closes the socket when we're not subscribed to anything. */
 let timeoutIDToAutoClose: number;
@@ -102,34 +102,6 @@ function cancelAllEchoTimers(): void {
 	echoTimers = {};
 }
 
-// On-Reply Functions ----------------------------------------------------------
-
-/**
- * Flags an outgoing message to execute a function when the server replies.
- * @param messageID - The ID of the outgoing message
- * @param onreplyFunc - The function to execute on reply
- */
-function scheduleOnreplyFunc(messageID: MessageID, onreplyFunc?: () => void): void {
-	if (!onreplyFunc) return;
-	onreplyFuncs[messageID] = onreplyFunc;
-}
-
-/**
- * When we receive a message with the `replyto` property,
- * executes the on-reply function for that sent message.
- */
-function executeOnreplyFunc(id: number | undefined): void {
-	if (id === undefined) return;
-	if (!onreplyFuncs[id]) return;
-	onreplyFuncs[id]();
-	delete onreplyFuncs[id];
-}
-
-/** Erases all on-reply functions. Called when the socket is terminated. */
-function resetOnreplyFuncs(): void {
-	onreplyFuncs = {};
-}
-
 // Timer Management ------------------------------------------------------------
 
 /** If we have zero subscriptions, resets the timer to auto-close the socket. */
@@ -167,11 +139,10 @@ function cancelHeartbeatTimer(): void {
 	}
 }
 
-/** Clears all timers and pending callbacks tied to the socket. Called when it's torn down. */
+/** Clears all timers tied to the socket. Called when it's torn down. */
 function clearPendingState(): void {
 	cancelAllEchoTimers();
 	cancelHeartbeatTimer();
-	resetOnreplyFuncs();
 }
 
 /**
@@ -191,33 +162,19 @@ function onHeartbeatTimeout(): void {
 // Sending Messages ------------------------------------------------------------
 
 /**
- * Sends a message to the server with the provided route, action, and values.
- * @param route - Where the server needs to forward this to. general/invites/game
+ * Sends a message to the server, lazily opening the socket if one isn't up yet.
+ *
+ * Fire-and-forget: a message that can't go out is dropped. Only protocol traffic belongs here —
+ * anything the user asked for goes through socketintents.submit() so a disconnect can't eat it.
+ * @param route - Where the server needs to forward this to. general/lobby/game
  * @param action - What action to take within the route.
  * @param value - The contents of the message
- * @param isUserAction - Whether this message is a direct result of a user action. Default: false
- * @param onreplyFunc - Optional function to execute when we receive the server's response.
- * @returns *true* if the message was able to send.
  */
-async function send(
-	route: string,
-	action: string,
-	value?: WebsocketMessageValue,
-	isUserAction?: boolean,
-	onreplyFunc?: () => void,
-): Promise<boolean> {
-	// Guard: messages to a subscription route require an active subscription.
-	if (socketsubs.validSubs.includes(route) && !socketsubs.areSubbedToSub(route)) {
-		console.error(`Can't send route '${route}' action '${action}' while not subscribed.`);
-		onreplyFunc?.();
-		return false;
-	}
+async function send(route: string, action: string, value?: WebsocketMessageValue): Promise<void> {
+	if (!(await socketman.establishSocket())) return;
 
-	if (!(await socketman.establishSocket())) {
-		if (isUserAction) console.error("Too many requests. Can't send socket message.");
-		onreplyFunc?.();
-		return false;
-	}
+	const socket = socketman.getSocket();
+	if (!socket || socket.readyState !== WebSocket.OPEN) return; // Died while we awaited it.
 
 	resetTimerToCloseSocket();
 
@@ -245,12 +202,7 @@ async function send(
 			timeSent: Date.now(),
 			timeoutID: window.setTimeout(() => onEchoTimeout(payload.id!), wsutil.ECHO_TIMEOUT),
 		};
-
-		scheduleOnreplyFunc(payload.id!, onreplyFunc);
 	}
-
-	const socket = socketman.getSocket();
-	if (!socket || socket.readyState !== WebSocket.OPEN) return false; // Closed state, can't send message.
 
 	const stringifiedMessage = JSON.stringify(payload);
 
@@ -260,8 +212,6 @@ async function send(
 			simulatedWebsocketLatencyMillis_Debug,
 		);
 	} else socket.send(stringifiedMessage); // Send immediately
-
-	return true;
 }
 
 // Exports --------------------------------------------------------------------
@@ -270,7 +220,6 @@ export default {
 	send,
 	cancelTimerOfMessageID,
 	clearPendingState,
-	executeOnreplyFunc,
 	rescheduleHeartbeatTimer,
 	alsoPrintIncomingEchos,
 };

--- a/src/client/scripts/esm/websocket/socketrouter.ts
+++ b/src/client/scripts/esm/websocket/socketrouter.ts
@@ -71,10 +71,7 @@ function onmessage(serverMessage: MessageEvent): void {
 			JSON.stringify(message),
 		);
 	}
-	socketmessages.send('general', 'echo', message.id);
-
-	// Execute any on-reply function
-	socketmessages.executeOnreplyFunc(message.replyto);
+	void socketmessages.send('general', 'echo', message.id);
 
 	switch (message.route) {
 		case 'general':

--- a/src/client/scripts/esm/websocket/socketschemas.ts
+++ b/src/client/scripts/esm/websocket/socketschemas.ts
@@ -47,6 +47,13 @@ const GeneralSchema = z.discriminatedUnion('action', [
 const SeeksListSchema = z.array(OutSeekSchema);
 const ViewerCountSchema = z.number().nonnegative();
 
+/** Tells us we're in a game — carried by the snapshot on subscribe, and pushed live thereafter. */
+const InGameSchema = z.strictObject({
+	id: GameIDSchema,
+	/** Whether the server wants THIS tab taken into the game, instead of shown the rejoin banner. */
+	navigate: z.boolean(),
+});
+
 /** Represents all possible types an incoming 'lobby' route websocket message contents could be. */
 export type LobbyMessage = z.infer<typeof LobbySchema>;
 const LobbySchema = z.discriminatedUnion('action', [
@@ -55,6 +62,8 @@ const LobbySchema = z.discriminatedUnion('action', [
 		value: z.strictObject({
 			seekslist: SeeksListSchema,
 			viewercount: ViewerCountSchema,
+			/** Present only if we're already in a game at the time we subscribe. */
+			ingame: InGameSchema.optional(),
 		}),
 	}),
 	z.strictObject({
@@ -64,14 +73,7 @@ const LobbySchema = z.discriminatedUnion('action', [
 		}),
 	}),
 	z.strictObject({ action: z.literal('viewercount'), value: ViewerCountSchema }),
-	z.strictObject({
-		action: z.literal('ingame'),
-		value: z.strictObject({
-			id: GameIDSchema,
-			/** Whether the server wants THIS tab taken into the game, instead of shown the rejoin banner. */
-			navigate: z.boolean(),
-		}),
-	}),
+	z.strictObject({ action: z.literal('ingame'), value: InGameSchema }),
 	z.strictObject({ action: z.literal('outgame') }),
 ]);
 
@@ -124,19 +126,16 @@ const MasterSchema = z.discriminatedUnion('route', [
 		id: z.number(),
 		route: z.literal('general'),
 		contents: GeneralSchema,
-		replyto: z.number().optional(),
 	}),
 	z.strictObject({
 		id: z.number(),
 		route: z.literal('lobby'),
 		contents: LobbySchema,
-		replyto: z.number().optional(),
 	}),
 	z.strictObject({
 		id: z.number(),
 		route: z.literal('game'),
 		contents: GameSchema,
-		replyto: z.number().optional(),
 	}),
 ]);
 

--- a/src/client/scripts/esm/websocket/socketschemas.ts
+++ b/src/client/scripts/esm/websocket/socketschemas.ts
@@ -16,18 +16,15 @@ import {
 	ClockValuesSchema,
 	DisconnectInfoSchema,
 	GameConclusionMessageSchema,
+	GameIDSchema,
 	GameStateMessageSchema,
+	InGameMessageSchema,
+	LobbyStateMessageSchema,
 	OpponentsMoveMessageSchema,
-	OutSeekSchema,
 	RematchOfferInfoSchema,
+	SeeksListSchema,
+	ViewerCountSchema,
 } from '../../../../shared/types.js';
-
-// Seek Helper Schemas ---------------------------------------------------------------
-
-// Game Helper Schemas ---------------------------------------------------------------
-
-/** Zod schema for the id of an online game. */
-const GameIDSchema = z.number().int().nonnegative();
 
 // General Schema ---------------------------------------------------------------
 
@@ -42,30 +39,12 @@ const GeneralSchema = z.discriminatedUnion('action', [
 	z.strictObject({ action: z.literal('protocolversion'), value: z.number() }),
 ]);
 
-// Seeks Schema ---------------------------------------------------------------
-
-const SeeksListSchema = z.array(OutSeekSchema);
-const ViewerCountSchema = z.number().nonnegative();
-
-/** Tells us we're in a game — carried by the snapshot on subscribe, and pushed live thereafter. */
-const InGameSchema = z.strictObject({
-	id: GameIDSchema,
-	/** Whether the server wants THIS tab taken into the game, instead of shown the rejoin banner. */
-	navigate: z.boolean(),
-});
+// Lobby Schema ---------------------------------------------------------------
 
 /** Represents all possible types an incoming 'lobby' route websocket message contents could be. */
 export type LobbyMessage = z.infer<typeof LobbySchema>;
 const LobbySchema = z.discriminatedUnion('action', [
-	z.strictObject({
-		action: z.literal('lobbysnapshot'),
-		value: z.strictObject({
-			seekslist: SeeksListSchema,
-			viewercount: ViewerCountSchema,
-			/** Present only if we're already in a game at the time we subscribe. */
-			ingame: InGameSchema.optional(),
-		}),
-	}),
+	z.strictObject({ action: z.literal('lobbystate'), value: LobbyStateMessageSchema }),
 	z.strictObject({
 		action: z.literal('seekslist'),
 		value: z.strictObject({
@@ -73,7 +52,7 @@ const LobbySchema = z.discriminatedUnion('action', [
 		}),
 	}),
 	z.strictObject({ action: z.literal('viewercount'), value: ViewerCountSchema }),
-	z.strictObject({ action: z.literal('ingame'), value: InGameSchema }),
+	z.strictObject({ action: z.literal('ingame'), value: InGameMessageSchema }),
 	z.strictObject({ action: z.literal('outgame') }),
 ]);
 

--- a/src/client/scripts/esm/websocket/socketsubs.ts
+++ b/src/client/scripts/esm/websocket/socketsubs.ts
@@ -9,9 +9,9 @@
 
 import socketmessages from './socketmessages.js';
 
-const validSubs = ['lobby', 'game'];
+const validSubs = ['lobby', 'game'] as const;
 
-type Sub = (typeof validSubs)[number];
+export type Sub = (typeof validSubs)[number];
 
 const subs: Record<Sub, boolean> = {
 	lobby: false,
@@ -67,13 +67,12 @@ function unsubFromSub(sub: Sub): void {
 	if (!areSubbedToSub(sub)) return; // Already unsubbed.
 	deleteSub(sub);
 	// Tell the server we no longer want updates.
-	socketmessages.send('general', 'unsub', sub);
+	void socketmessages.send('general', 'unsub', sub);
 }
 
 // Exports --------------------------------------------------------------------
 
 export default {
-	validSubs,
 	zeroSubs,
 	areSubbedToSub,
 	addSub,

--- a/src/server/game/gamemanager/gamerouter.ts
+++ b/src/server/game/gamemanager/gamerouter.ts
@@ -43,7 +43,6 @@ type GameMessage = z.infer<typeof GameSchema>;
  * Possible actions: submitmove/offerdraw/abort/resign/subscribe/subscriberematch/paste...
  * @param ws - The socket
  * @param contents - The incoming websocket message, with the properties `route`, `action`, `value`, `id`.
- * @param id - The id of the incoming message. This should be included in our response as the `replyto` property.
  */
 function routeGameMessage(ws: CustomWebSocket, contents: GameMessage): void {
 	// All actions that don't require a game

--- a/src/server/game/seeksmanager/lobbymanager.ts
+++ b/src/server/game/seeksmanager/lobbymanager.ts
@@ -105,14 +105,25 @@ function broadcastMemberInGameStatus(
 }
 
 /**
- * Sends the full lobby snapshot state (seeks list + current viewer count) to a single client.
- * Called once when a socket first subscribes.
+ * Sends the full lobby snapshot state (seeks list, viewer count, and whether they're already
+ * in a game) to a single client. Called once when a socket first subscribes — everything the
+ * client needs to be fully in sync arrives in this one message.
  * @param ws - The socket of the player to send the snapshot to.
  * @param seekslist - The current list of seeks.
  */
 function sendClientLobbySnapshot(ws: CustomWebSocket, seekslist: OutSeek[]): void {
 	const viewercount = getSubscriberCount();
-	const message = { seekslist, viewercount };
+
+	// If they're already in a game, tell them. They're only taken into it if we still owe them
+	// the notice (their seek was accepted during a disconnect cushion, so they never got the
+	// push at creation) — otherwise they just get the banner to rejoin it.
+	const gameID = getIDOfGamePlayerIsIn(ws.metadata.memberInfo);
+	const ingame =
+		gameID !== undefined
+			? { id: gameID, navigate: consumeNavigateNotice(ws.metadata.memberInfo) }
+			: undefined;
+
+	const message = { seekslist, viewercount, ingame };
 	sendSocketMessage(ws, 'lobby', 'lobbysnapshot', message); // In order: socket, sub, action, value
 }
 
@@ -209,7 +220,7 @@ function findSocketFromOwner(owner: AuthMemberInfo): CustomWebSocket | undefined
 
 /**
  * Subscribes a socket to the lobby,
- * sends them the list of active seeks,
+ * sends them the full lobby snapshot,
  * and cancels any active timers to delete their seeks if
  * their socket was previously closed by a network interruption.
  */
@@ -217,15 +228,6 @@ function subToLobby(ws: CustomWebSocket): void {
 	if (ws.metadata.subscriptions.lobby) return; // Already subscribed. Happens occasionally
 
 	addSocketToLobbySubs(ws);
-
-	// If they're already in a game, tell them. They're only taken into it if we still owe them
-	// the notice (their seek was accepted during a disconnect cushion, so they never got the
-	// push at creation) — otherwise they just get the banner to rejoin it.
-	const gameID = getIDOfGamePlayerIsIn(ws.metadata.memberInfo);
-	if (gameID !== undefined) {
-		const navigate = consumeNavigateNotice(ws.metadata.memberInfo);
-		sendSocketMessage(ws, 'lobby', 'ingame', { id: gameID, navigate });
-	}
 
 	sendClientLobbySnapshot(ws, getSeeksListSafe());
 	broadcastViewerCount(ws); // Notify all existing subscribers of the incremented count

--- a/src/server/game/seeksmanager/lobbymanager.ts
+++ b/src/server/game/seeksmanager/lobbymanager.ts
@@ -6,9 +6,9 @@
  * and broadcasts changes out to the clients.
  */
 
-import type { OutSeek } from '../../../shared/types.js';
 import type { AuthMemberInfo } from '../../types.js';
 import type { CustomWebSocket } from '../../socket/socketUtility.js';
+import type { OutSeek, LobbyStateMessage } from '../../../shared/types.js';
 
 import { memberInfoEq } from '../../utility/memberInfoUtil.js';
 import { sendSocketMessage } from '../../socket/sendSocketMessage.js';
@@ -105,13 +105,13 @@ function broadcastMemberInGameStatus(
 }
 
 /**
- * Sends the full lobby snapshot state (seeks list, viewer count, and whether they're already
+ * Sends the full lobby state (seeks list, viewer count, and whether they're already
  * in a game) to a single client. Called once when a socket first subscribes — everything the
  * client needs to be fully in sync arrives in this one message.
- * @param ws - The socket of the player to send the snapshot to.
- * @param seekslist - The current list of seeks.
+ * @param ws - The socket of the player to send the state to.
  */
-function sendClientLobbySnapshot(ws: CustomWebSocket, seekslist: OutSeek[]): void {
+function sendClientLobbyState(ws: CustomWebSocket): void {
+	const seekslist = getSeeksListSafe();
 	const viewercount = getSubscriberCount();
 
 	// If they're already in a game, tell them. They're only taken into it if we still owe them
@@ -123,14 +123,14 @@ function sendClientLobbySnapshot(ws: CustomWebSocket, seekslist: OutSeek[]): voi
 			? { id: gameID, navigate: consumeNavigateNotice(ws.metadata.memberInfo) }
 			: undefined;
 
-	const message = { seekslist, viewercount, ingame };
-	sendSocketMessage(ws, 'lobby', 'lobbysnapshot', message); // In order: socket, sub, action, value
+	const message: LobbyStateMessage = { seekslist, viewercount, ingame };
+	sendSocketMessage(ws, 'lobby', 'lobbystate', message); // In order: socket, sub, action, value
 }
 
 /**
  * Broadcasts the current viewer count to all subscribed clients.
  * Called when the subscriber count changes (i.e. on sub/unsub), not on seek changes.
- * @param skipWs - Optional socket to exclude from the broadcast (e.g. the socket that just subscribed, who already received the count in their lobbysnapshot).
+ * @param skipWs - Optional socket to exclude from the broadcast (e.g. the socket that just subscribed, who already received the count in their lobbystate).
  */
 function broadcastViewerCount(skipWs?: CustomWebSocket): void {
 	const count = getSubscriberCount();
@@ -213,23 +213,22 @@ function findSocketFromOwner(owner: AuthMemberInfo): CustomWebSocket | undefined
 	for (const ws of getLobbySubscribers()) {
 		if (memberInfoEq(owner, ws.metadata.memberInfo)) return ws;
 	}
-
-	console.log(`Unable to find a lobby subscriber that belongs to ${JSON.stringify(owner)}!`);
-	return undefined;
+	// They must have disconnected involuntarily, and be within
+	// that 5-second cushion before their seek is deleted.
+	return;
 }
 
 /**
- * Subscribes a socket to the lobby,
- * sends them the full lobby snapshot,
- * and cancels any active timers to delete their seeks if
- * their socket was previously closed by a network interruption.
+ * Subscribes a socket to the lobby, sends them the full lobby state,
+ * and cancels any active timers to delete their seeks if their
+ * socket was previously closed by a network interruption.
  */
 function subToLobby(ws: CustomWebSocket): void {
 	if (ws.metadata.subscriptions.lobby) return; // Already subscribed. Happens occasionally
 
 	addSocketToLobbySubs(ws);
 
-	sendClientLobbySnapshot(ws, getSeeksListSafe());
+	sendClientLobbyState(ws);
 	broadcastViewerCount(ws); // Notify all existing subscribers of the incremented count
 	cancelTimerToDeleteUsersSeeksFromNetworkInterruption(ws);
 }

--- a/src/server/socket/sendSocketMessage.ts
+++ b/src/server/socket/sendSocketMessage.ts
@@ -20,18 +20,14 @@ import { addTimeoutToEchoTimers, deleteEchoTimerForMessageID } from './echoTrack
 
 /** Represents an outgoing WebSocket server message. */
 interface WebsocketOutMessage {
-	/** The route to forward the message to (e.g., "general", "lobby", "game", "echo").
-	 * Undefined if it's a reply-only message. */
-	route?: string;
+	/** The route to forward the message to (e.g., "general", "lobby", "game", "echo"). */
+	route: string;
 	/** The message contents. For echo messages, this is the message ID being echoed.
-	 * For other messages, this is an object with action and value.
-	 * Absent for reply-only acknowledgement messages (route and action are both undefined). */
-	contents?: any;
+	 * For other messages, this is an object with action and value. */
+	contents: any;
 	/** The ID of the message to echo, indicating the connection is still active.
 	 * Or undefined if this message itself is an echo. */
 	id?: number;
-	/** Optionally, we can include the id of the incoming message that this outgoing message is the reply to. */
-	replyto?: number;
 }
 
 import type { CustomWebSocket } from './socketUtility.js';
@@ -57,22 +53,20 @@ if (process.env['NODE_ENV'] !== 'development' && simulatedWebsocketLatencyMillis
  * @param route - What subscription/route this message should be forwarded to.
  * @param action - What type of action the client should take within the subscription route.
  * @param value - The contents of the message.
- * @param [replyto] If applicable, the id of the socket message this message is a reply to.
  * @param [options] - Additional options for sending the message.
  * @param [options.skipLatency=false] - If true, we send the message immediately, without waiting for simulated latency again.
  */
 function sendSocketMessage(
 	ws: CustomWebSocket,
-	route: string | undefined,
-	action: string | undefined,
+	route: string,
+	action: string,
 	value?: any,
-	replyto?: number,
 	{ skipLatency }: { skipLatency?: boolean } = {},
 ): void {
 	// If we're applying simulated latency delay, set a timer to send this message.
 	if (simulatedWebsocketLatencyMillis !== 0 && !skipLatency) {
 		setTimeout(() => {
-			sendSocketMessage(ws, route, action, value, replyto, { skipLatency: true });
+			sendSocketMessage(ws, route, action, value, { skipLatency: true });
 		}, simulatedWebsocketLatencyMillis);
 		return;
 	}
@@ -83,28 +77,19 @@ function sendSocketMessage(
 	if (ws.readyState !== WebSocket.OPEN) return;
 
 	const isEcho = action === 'echo';
-	// Reply-only messages should have no empty "contents" field
-	const isReplyOnly = route === undefined;
 	const payload: WebsocketOutMessage = isEcho
 		? {
 				route: 'echo',
 				contents: value, // For echo, value contains the message ID
-				replyto,
 			}
-		: isReplyOnly
-			? {
-					id: uuid.generateNumbID(10),
-					replyto,
-				}
-			: {
-					route,
-					contents: {
-						action,
-						value,
-					},
-					id: uuid.generateNumbID(10), // Only include an id (and accept an echo back) if this is NOT an echo itself!
-					replyto,
-				};
+		: {
+				route,
+				contents: {
+					action,
+					value,
+				},
+				id: uuid.generateNumbID(10), // Only include an id (and accept an echo back) if this is NOT an echo itself!
+			};
 	const stringifiedPayload = JSON.stringify(payload);
 
 	// if (!isEcho) console.log(`Sending: ${stringifiedPayload}`);
@@ -130,16 +115,10 @@ function sendSocketMessage(
  * Sends a notification message to the client through the WebSocket connection, to be displayed on-screen.
  * @param ws - The WebSocket connection object.
  * @param translationCode - The code corresponding to the message that needs to be retrieved for language-specific translation. For example, `"server.javascript.ws-already_in_game"`.
- * @param [options] - An object containing additional options.
- * @param [options.replyto] - The ID of the incoming WebSocket message to which this message is replying.
  */
-function sendNotify(
-	ws: CustomWebSocket,
-	translationCode: TranslationKeys,
-	{ replyto }: { replyto?: number } = {},
-): void {
+function sendNotify(ws: CustomWebSocket, translationCode: TranslationKeys): void {
 	const text = getTranslation(translationCode, ws.metadata.cookies.lang);
-	sendSocketMessage(ws, 'general', 'notify', text, replyto);
+	sendSocketMessage(ws, 'general', 'notify', text);
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -57,6 +57,9 @@ export const ServerUsernameContainerSchema = z.strictObject({
 
 // Game Helper Schemas ---------------------------------------------------------------
 
+/** The id of an online game. */
+export const GameIDSchema = z.number().int().nonnegative();
+
 /** The values of each color's clock, and which one is currently counting down, if any. */
 export type ClockValues = z.infer<typeof ClockValuesSchema>;
 export const ClockValuesSchema = z.strictObject({
@@ -354,6 +357,30 @@ export const BaseSeekSchema = z.strictObject({
 export type OutSeek = z.infer<typeof OutSeekSchema>;
 export const OutSeekSchema = BaseSeekSchema.extend({
 	variant: OutSeekVariantSchema,
+});
+
+// Lobby State Schemas ---------------------------------------------------------------
+
+/** Every seek currently open in the lobby. */
+export const SeeksListSchema = z.array(OutSeekSchema);
+
+/** How many clients are currently viewing the lobby. */
+export const ViewerCountSchema = z.number().nonnegative();
+
+/** Tells us we're in a game — carried by the lobby state on subscribe, and pushed live thereafter. */
+export const InGameMessageSchema = z.strictObject({
+	id: GameIDSchema,
+	/** Whether the server wants THIS tab taken into the game, instead of shown the rejoin banner. */
+	navigate: z.boolean(),
+});
+
+/** The payload of the `lobbystate` message — the full lobby snapshot, sent the moment we subscribe. */
+export type LobbyStateMessage = z.infer<typeof LobbyStateMessageSchema>;
+export const LobbyStateMessageSchema = z.strictObject({
+	seekslist: SeeksListSchema,
+	viewercount: ViewerCountSchema,
+	/** Present only if we're already in a game at the time we subscribe. */
+	ingame: InGameMessageSchema.optional(),
 });
 
 // Create Seek Schemas ---------------------------------------------------------------


### PR DESCRIPTION
## The bug

Clicking "Create online game" while the socket was down logged an error and dropped the message:

```
WebSocket connection closed: 1006
socketmessages.ts:206 Can't send route 'lobby' action 'createseek' while not subscribed.
```

The subscription guard in `send()` rejected it *before* the lazy-reconnect stall was ever reached — a close clears all subscriptions, so the guard always fires. This was never specific to `createseek`: `resign`, `abort`, draw offers, disconnect claims and every seek action were lost the same way.

## The fix

`socketintents.submit()` — a delivery layer over `send()` for anything the user asked for. An intent that can't go out right now is held per route and released once that route's full state has been **applied**, with each one re-checked against that state first. So a held `resign` is dropped if the game ended meanwhile, a held `acceptseek` is dropped if we're already in a game, and so on. A 10s lifetime backstops the case where the user has long since assumed their click didn't register.

Protocol traffic keeps using `send()` directly. Deferring the subscribes the resync depends on would deadlock the queue against itself, and moves already reconcile through `resyncer`.

The release point is deliberately *after* the resync handler rather than alongside `setInSync(true)` — the validity checks read the reconciled board, but `inSync` has to be set beforehand so resyncer can submit moves as it reconciles. Two distinct moments that currently look like one; there's a comment at the site.

## Also in here

- **`ingame`/`outgame` folded into the lobby snapshot**, mirroring how `gamestate` carries everything the game page needs to be fully in sync. The live pushes stay — only the sub-time send goes. This gives the lobby a single in-sync moment to release intents from, and the seek predicates depend on it.
- **On-reply machinery deleted**, dead on both ends: no callsite ever passed an `onreplyFunc`, and no server handler ever passed `replyto`. Removes the client registry, the schema fields, and the server's `replyto` parameter and its reply-only payload branch.
- **`send()` no longer reports whether it sent.** Nothing consumed the boolean and it never meant delivery. Its now-unreachable subscription guard and `isUserAction` flag go with it, and it no longer arms an echo timer for a message it turns out it can't send.
- `validSubs` is `as const`, so `Sub` is `'lobby' | 'game'` instead of widening to `string`.

## Notes for review

- `isClaimable()` in `guidisconnect.ts` checks `isGameLive()` first, and that check is load-bearing rather than decorative — online games don't dispatch `game-concluded` off a locally-detected mate, so `claimableAt` briefly outlives the game. Commented at the site.
- `cancelseek`'s check is by seek *presence*, not ownership: the invite tag that ownership derives from is deleted at click time.

`npm run type-check && npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)